### PR TITLE
Add the CommandLineParser class

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -2,4 +2,4 @@
 --hide-void-return
 --markup-provider=redcarpet
 --markup markdown
-- LICENSE.md
+- LICENSE.txt

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 James
+Copyright (c) 2022 James Couball
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -60,4 +60,5 @@ Bug reports and pull requests are welcome on
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the
+[MIT License](https://github.com/main-branch/create_github_release/blob/main/LICENSE.txt).

--- a/Rakefile
+++ b/Rakefile
@@ -58,6 +58,7 @@ CLEAN << 'rubocop-report.json'
 require 'yard'
 YARD::Rake::YardocTask.new do |t|
   t.files = %w[lib/**/*.rb examples/**/*]
+  t.stats_options = ['--list-undoc']
 end
 
 CLEAN << '.yardoc'

--- a/lib/create_github_release.rb
+++ b/lib/create_github_release.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'create_github_release/version'
-require_relative 'create_github_release/options'
+require 'create_github_release/command_line_parser'
+require 'create_github_release/options'
+require 'create_github_release/version'
 
 # Main module for this gem
 module CreateGithubRelease

--- a/lib/create_github_release/command_line_parser.rb
+++ b/lib/create_github_release/command_line_parser.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'create_github_release/options'
+
+module CreateGithubRelease
+  # Parses the options for this script
+  #
+  # @example Specifying the release type
+  #   parser = CommandLineParser.new
+  #   parser.parse(['major'])
+  #   options = parser.options
+  #   options.release_type # => "major"
+  #   options.quiet # => false
+  #
+  # @example Specifying the release type and the quiet option
+  #   parser = CommandLineParser.new
+  #   parser.parse(['--quiet', 'minor'])
+  #   options = parser.options
+  #   options.release_type # => "minor"
+  #   options.quiet # => true
+  #
+  # @example Showing the command line help
+  #   parser = CommandLineParser.new
+  #   parser.parse(['--help'])
+  #
+  # @api public
+  #
+  class CommandLineParser
+    # Create a new command line parser
+    #
+    # @example
+    #   parser = CommandLineParser.new
+    #
+    def initialize
+      @option_parser = OptionParser.new
+      define_options
+      @options = CreateGithubRelease::Options.new
+    end
+
+    # Parse the command line arguements returning the options
+    #
+    # @example
+    #   parser = CommandLineParser.new
+    #   options = parser.parse(['major'])
+    #
+    # @param args [Array<String>] the command line arguments
+    #
+    # @return [CreateGithubRelease::Options] the options
+    #
+    def parse(args)
+      option_parser.parse!(remaining_args = args.dup)
+      parse_remaining_args(remaining_args)
+      # puts options unless options.quiet
+      options
+    end
+
+    private
+
+    # @!attribute [rw] options
+    #
+    # The options to used for the create-github-release script
+    #
+    # @example
+    #   parser = CommandLineParser.new
+    #   parser.parse(['major'])
+    #   options = parser.options
+    #   options.release_type # => 'major'
+    #
+    # @return [CreateGithubRelease::Options] the options
+    #
+    # @api private
+    #
+    attr_reader :options
+
+    # @!attribute [rw] option_parser
+    #
+    # The option parser
+    #
+    # @return [OptionParser] the option parser
+    #
+    # @api private
+    #
+    attr_reader :option_parser
+
+    # Parse non-option arguments (the release type)
+    # @return [void]
+    # @api private
+    def parse_remaining_args(remaining_args)
+      error_with_usage('No release type specified') if remaining_args.empty?
+      options.release_type = remaining_args.shift || nil
+      error_with_usage('Too many args') unless remaining_args.empty?
+    end
+
+    # Output an error message and useage to stderr and exit
+    # @return [void]
+    # @api private
+    def error_with_usage(message)
+      warn <<~MESSAGE
+        ERROR: #{message}
+        #{option_parser}
+      MESSAGE
+      exit 1
+    end
+
+    # Define the options for OptionParser
+    # @return [void]
+    # @api private
+    def define_options
+      option_parser.banner = 'Usage: create_release --help | release-type'
+      option_parser.separator ''
+      option_parser.separator 'Options:'
+
+      define_quiet_option
+      define_help_option
+    end
+
+    # Define the quiet option
+    # @return [void]
+    # @api private
+    def define_quiet_option
+      option_parser.on('-q', '--[no-]quiet', 'Do not show output') do |quiet|
+        options.quiet = quiet
+      end
+    end
+
+    # Define the help option
+    # @return [void]
+    # @api private
+    def define_help_option
+      option_parser.on_tail('-h', '--help', 'Show this message') do
+        puts option_parser
+        exit 0
+      end
+    end
+  end
+end

--- a/lib/create_github_release/version.rb
+++ b/lib/create_github_release/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module CreateGithubRelease
+  # The version of this gem
   VERSION = '0.1.0'
 end

--- a/spec/create_github_release/command_line_parser_spec.rb
+++ b/spec/create_github_release/command_line_parser_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
+RSpec.describe CreateGithubRelease::CommandLineParser do
+  let(:parser) { described_class.new }
+
+  describe '#initialize' do
+    subject { parser }
+    it { is_expected.to be_a described_class }
+  end
+
+  describe '#parse' do
+    subject { parser.parse(args) }
+    context 'when given patch for release type' do
+      let(:args) { ['patch'] }
+      it { is_expected.to have_attributes(release_type: 'patch', quiet: false) }
+    end
+
+    context 'when a release type is not given' do
+      let(:args) { [] }
+      it 'should exit' do
+        expect { subject }.to raise_error(SystemExit).and output(/^ERROR: No release type specified/).to_stderr
+      end
+    end
+
+    context 'when too many args are given' do
+      let(:args) { %w[major minor] }
+      it 'should exit' do
+        expect { subject }.to raise_error(SystemExit).and output(/^ERROR: Too many args/).to_stderr
+      end
+    end
+
+    context 'when the --quiet option is given' do
+      let(:args) { ['--quiet', 'patch'] }
+      it { is_expected.to have_attributes(release_type: 'patch', quiet: true) }
+    end
+
+    context 'when the --help options is given' do
+      let(:args) { ['--help'] }
+      it 'should exit and display the help message' do
+        expect { subject }.to raise_error(SystemExit).and output(/^Usage: /).to_stdout
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `CommandLineParser` class parses the command line for the `create-github-release` command.

It allows the following command lines:

```shell
create-github-release --help
```

```shell
create-github-release [--quiet] release_type
```

where `release_type` is `major`, `minor`, or `patch`

Example usage:

```ruby
args = ['--quiet', 'major']
options = CreateGithubRelease::CommandLineParser.new.parse(args)
options.quiet # => true
options.release_type # => "major"
```
