### PR TITLE
Add release assertions

### DIFF
--- a/exe/create-github-release
+++ b/exe/create-github-release
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'create_github_release'
+
+options = CreateGithubRelease::CommandLineParser.new.parse(ARGV)
+CreateGithubRelease::ReleaseAssertions.new(options).make_assertions
+puts unless options.quiet
+# CreateGithubRelease::ReleaseCreator.new(options).create_release
+
+puts <<~MESSAGE unless options.quiet
+  Release '#{options.tag}' created successfully
+  See the release notes at #{options.release_url}
+
+  Next steps:
+  * Get someone to review and approve the release pull request
+  * Merge the pull request manually from the command line with the following commands:
+
+  git checkout #{options.default_branch}
+  git merge --ff-only #{options.branch}
+  git push
+MESSAGE

--- a/lib/create_github_release.rb
+++ b/lib/create_github_release.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require 'create_github_release/assertion_base'
+require 'create_github_release/assertions'
 require 'create_github_release/command_line_parser'
 require 'create_github_release/options'
+require 'create_github_release/release_assertions'
 require 'create_github_release/version'
 
 # Main module for this gem

--- a/lib/create_github_release/assertion_base.rb
+++ b/lib/create_github_release/assertion_base.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module CreateGithubRelease
+  # Base class for assertions
+  #
+  # All assertions must inherit from this class.
+  # It holds the options and knows how to print, puts and error while respecting the `quiet` flag.
+  #
+  # @api private
+  #
+  class AssertionBase
+    # Create a new assertion object and save the given `options`
+    # @param options [CreateGithubRelease::Options] the options
+    # @api private
+    def initialize(options)
+      @options = options
+    end
+
+    # This method must be overriden by a subclass
+    #
+    # The subclass is expected to call `error` if the assertion fails.
+    #
+    # @return [void]
+    #
+    # @api private
+    def assert
+      raise NotImplementedError
+    end
+
+    # @!attribute [r] options
+    #
+    # The options passed to the assertion object
+    # @return [CreateGithubRelease::Options] the options
+    # @api private
+    attr_reader :options
+
+    # Calls `Kernel.print` if the `quiet` flag is not set in the `options`
+    # @param args [Array] the arguments to pass to `Kernel.print`
+    # @return [void]
+    # @api private
+    def print(*args)
+      super unless options.quiet
+    end
+
+    # Calls `Kernel.puts` if the `quiet` flag is not set in the `options`
+    # @param args [Array] the arguments to pass to `Kernel.puts`
+    # @return [void]
+    # @api private
+    def puts(*args)
+      super unless options.quiet
+    end
+
+    # Writes a message to stderr and exits with exitcode 1
+    # @param message [String] the message to write to stderr
+    # @return [void]
+    # @api private
+    def error(message)
+      warn "ERROR: #{message}"
+      exit 1
+    end
+  end
+end

--- a/lib/create_github_release/assertions.rb
+++ b/lib/create_github_release/assertions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative 'assertions/bundle_is_up_to_date'
+require_relative 'assertions/changelog_docker_container_exists'
+require_relative 'assertions/docker_is_running'
+require_relative 'assertions/gh_command_exists'
+require_relative 'assertions/in_git_repo'
+require_relative 'assertions/in_repo_root_directory'
+require_relative 'assertions/local_and_remote_on_same_commit'
+require_relative 'assertions/no_staged_changes'
+require_relative 'assertions/no_uncommitted_changes'
+require_relative 'assertions/on_default_branch'
+require_relative 'assertions/release_branch_does_not_exist'
+require_relative 'assertions/release_tag_does_not_exist'

--- a/lib/create_github_release/assertions/bundle_is_up_to_date.rb
+++ b/lib/create_github_release/assertions/bundle_is_up_to_date.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that options.branch does not exist
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class BundleIsUpToDate < AssertionBase
+      # Make sure the bundle is up to date
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::BundleIsUpToDate.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        print 'Checking that the bundle is up to date...'
+        if File.exist?('Gemfile.lock')
+          run_bundle_update
+        else
+          run_bundle_install
+        end
+      end
+
+      private
+
+      # Run bundle update
+      # @return [void]
+      # @raise [SystemExit] if bundle update fails
+      # @api private
+      def run_bundle_update
+        print 'Running bundle update...'
+        `bundle update --quiet`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'bundle update failed'
+        end
+      end
+
+      # Run bundle install
+      # @return [void]
+      # @raise [SystemExit] if bundle update fails
+      # @api private
+      def run_bundle_install
+        print 'Running bundle install...'
+        `bundle install --quiet`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'bundle install failed'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/changelog_docker_container_exists.rb
+++ b/lib/create_github_release/assertions/changelog_docker_container_exists.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'tmpdir'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that the changelog docker container exists
+    #
+    # @api public
+    #
+    class ChangelogDockerContainerExists < AssertionBase
+      # Make sure the changelog docker container exists
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::ChangelogDockerContainerExists.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        Dir.mktmpdir do |dir|
+          @dir = dir
+          @docker_file = "#{dir}/Dockerfile"
+          File.write(@docker_file, DOCKERFILE)
+          assert_changelog_docker_container_exists
+        end
+      end
+
+      private
+
+      # Create the changelog docker container
+      # @return [void]
+      # @raise [SystemExit] if docker build fails
+      # @api private
+      def assert_changelog_docker_container_exists
+        print 'Checking that the changelog docker container exists (might take time to build)...'
+        `docker build --file "#{@docker_file}" --tag changelog-rs . 1>/dev/null 2>#{@dir}/stderr`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'Failed to build the changelog-rs docker container'
+        end
+      end
+
+      DOCKERFILE = <<~CONTENTS
+        FROM rust
+
+        # Build the docker image (from this project's root directory):
+        # docker build --file Dockerfile.changelog-rs --tag changelog-rs .
+        #
+        # Use this image to output a changelog (from this project's root directory):
+        # docker run --rm --volume "$PWD:/worktree" changelog-rs v1.9.1 v1.10.0
+
+        RUN cargo install changelog-rs
+        WORKDIR /worktree
+
+        ENTRYPOINT ["/usr/local/cargo/bin/changelog-rs", "/worktree"]
+      CONTENTS
+    end
+  end
+end

--- a/lib/create_github_release/assertions/docker_is_running.rb
+++ b/lib/create_github_release/assertions/docker_is_running.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that docker is running
+    #
+    # @api public
+    #
+    class DockerIsRunning < AssertionBase
+      # Make sure that docker is running
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::DockerIsRunning.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        print 'Checking that docker is installed and running...'
+        `docker info > /dev/null 2>&1`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'Docker is not installed or not running'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/gh_command_exists.rb
+++ b/lib/create_github_release/assertions/gh_command_exists.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that the 'gh' command is in the path
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class GhCommandExists < AssertionBase
+      # Make sure that the 'gh' command is in the path
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::GhCommandExists.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        print 'Checking that the gh command exists...'
+        `which gh > /dev/null 2>&1`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'The gh command was not found'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/in_git_repo.rb
+++ b/lib/create_github_release/assertions/in_git_repo.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that the current directory is a git repository
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class InGitRepo < AssertionBase
+      # Make sure that the current directory is a git repository
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::InGitRepo.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        print 'Checking that you are in a git repo...'
+        `git rev-parse --is-inside-work-tree --quiet > /dev/null 2>&1`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'You are not in a git repo'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/in_repo_root_directory.rb
+++ b/lib/create_github_release/assertions/in_repo_root_directory.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'fileutils'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that the current directory is the root of the repository
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class InRepoRootDirectory < AssertionBase
+      # Make sure that the current directory is the root of the repository
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::InRepoRootDirectory.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        print "Checking that you are in the repo's root directory..."
+        toplevel_directory = `git rev-parse --show-toplevel`.chomp
+        if toplevel_directory == FileUtils.pwd
+          puts 'OK'
+        else
+          error "You are not in the repo's root directory"
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/local_and_remote_on_same_commit.rb
+++ b/lib/create_github_release/assertions/local_and_remote_on_same_commit.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that the local working directory and the remote are on the same commit
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class LocalAndRemoteOnSameCommit < AssertionBase
+      # Make sure that the local working directory and the remote are on the same commit
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::LocalAndRemoteOnSameCommit.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        print 'Checking that local and remote are on the same commit...'
+        local_commit = `git rev-parse HEAD`.chomp
+        remote_commit = `git ls-remote '#{options.remote}' '#{options.default_branch}' | cut -f 1`.chomp
+        if local_commit == remote_commit
+          puts 'OK'
+        else
+          error 'Local and remote are not on the same commit'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/no_staged_changes.rb
+++ b/lib/create_github_release/assertions/no_staged_changes.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that there are no staged changes in the local repository
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class NoStagedChanges < AssertionBase
+      # Assert that there are no staged changes in the local repository
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::NoStagedChanges.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        print 'Checking that there are no staged changes...'
+        if `git diff --staged --name-only | wc -l`.to_i.zero? && $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'There are staged changes'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/no_uncommitted_changes.rb
+++ b/lib/create_github_release/assertions/no_uncommitted_changes.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that there are no uncommitted changes in the local working copy
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class NoUncommittedChanges < AssertionBase
+      # Assert that there are no uncommitted changes in the local working copy
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::NoUncommittedChanges.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        print 'Checking that there are no uncommitted changes...'
+        if `git status --porcelain | wc -l`.to_i.zero? && $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'There are uncommitted changes'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/on_default_branch.rb
+++ b/lib/create_github_release/assertions/on_default_branch.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that the default branch is checked out
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class OnDefaultBranch < AssertionBase
+      # Assert that the default branch is checked out
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::OnDefaultBranch.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        print 'Checking that you are on the default branch...'
+        current_branch = `git branch --show-current`.chomp
+        if current_branch == options.default_branch
+          puts 'OK'
+        else
+          error "You are not on the default branch '#{options.default_branch}'"
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/release_branch_does_not_exist.rb
+++ b/lib/create_github_release/assertions/release_branch_does_not_exist.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that the release branch does not exist
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class ReleaseBranchDoesNotExist < AssertionBase
+      # Assert that the release branch does not exist
+      #
+      # Checks both the local repository and the remote repository.
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::ReleaseBranchDoesNotExist.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        assert_does_not_exist_locally
+        assert_does_not_exist_remotely
+      end
+
+      private
+
+      # Assert that the release branch does not exist locally
+      # @return [void]
+      # @raise [SystemExit] if bundle update fails
+      # @api private
+      def assert_does_not_exist_locally
+        print "Checking that local branch ' #{options.branch}' does not exist..."
+
+        if `git branch --list '#{options.branch}' | wc -l`.to_i.zero? && $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error "'#{options.branch}' already exists."
+        end
+      end
+
+      # Assert that the release branch does not exist remotely
+      # @return [void]
+      # @raise [SystemExit] if bundle update fails
+      # @api private
+      def assert_does_not_exist_remotely
+        print "Checking that the remote branch '#{options.branch}' does not exist..."
+        `git ls-remote --heads --exit-code '#{options.remote}' '#{options.branch}' >/dev/null 2>&1`
+        if $CHILD_STATUS.success?
+          error "'#{options.branch}' already exists"
+        else
+          puts 'OK'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/assertions/release_tag_does_not_exist.rb
+++ b/lib/create_github_release/assertions/release_tag_does_not_exist.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module CreateGithubRelease
+  module Assertions
+    # Assert that the release tag does not exist
+    #
+    # Checks both the local repository and the remote repository.
+    #
+    # @api public
+    #
+    class ReleaseTagDoesNotExist < AssertionBase
+      # Assert that the release tag does not exist
+      #
+      # Checks both the local repository and the remote repository.
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   assertion = CreateGithubRelease::Assertions::ReleaseTagDoesNotExist.new(options)
+      #   begin
+      #     assertion.assert
+      #     puts 'Assertion passed'
+      #   rescue SystemExit
+      #     puts 'Assertion failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the assertion fails
+      #
+      def assert
+        local_tag_does_not_exist
+        remote_tag_does_not_exist
+      end
+
+      private
+
+      # Assert that the release branch does not exist locally
+      # @return [void]
+      # @raise [SystemExit] if bundle update fails
+      # @api private
+      def local_tag_does_not_exist
+        print "Checking that local tag '#{options.tag}' does not exist..."
+
+        tags = `git tag --list "#{options.tag}"`.chomp
+        error 'Could not list tags' unless $CHILD_STATUS.success?
+
+        if tags.split.empty?
+          puts 'OK'
+        else
+          error "Local tag '#{options.tag}' already exists"
+        end
+      end
+
+      # Assert that the release branch does not exist remotely
+      # @return [void]
+      # @raise [SystemExit] if bundle update fails
+      # @api private
+      def remote_tag_does_not_exist
+        print "Checking that the remote tag '#{options.tag}' does not exist..."
+        `git ls-remote --tags --exit-code '#{options.remote}' #{options.tag} >/dev/null 2>&1`
+        if $CHILD_STATUS.success?
+          error "Remote tag '#{options.tag}' already exists"
+        else
+          puts 'OK'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/release_assertions.rb
+++ b/lib/create_github_release/release_assertions.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'create_github_release/assertions'
+
+module CreateGithubRelease
+  # Assertions that must be true for a new Github release to be created
+  #
+  # @example
+  #   require 'create_github_release'
+  #
+  #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+  #   assertions = CreateGithubRelease::ReleaseAssertions.new(options)
+  #   assertions.options # => #<CreateGithubRelease::Options:0x00007f9b0a0b0a00>
+  #
+  # @api public
+  #
+  class ReleaseAssertions
+    # The options used in the assertions
+    #
+    # @example
+    #   require 'create_github_release'
+    #
+    #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+    #   assertions = CreateGithubRelease::ReleaseAssertions.new(options)
+    #   assertions.options # => #<CreateGithubRelease::Options:0x00007f9b0a0b0a00>
+    #
+    # @return [CreateGithubRelease::Options]
+    attr_reader :options
+
+    # Create a new instance of ReleaseAssertions
+    #
+    # @example
+    #   require 'create_github_release'
+    #
+    #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+    #   assertions = CreateGithubRelease::ReleaseAssertions.new(options)
+    #   assertions.make_assertions
+    #
+    def initialize(options)
+      @options = options
+    end
+
+    ASSERTIONS = [
+      CreateGithubRelease::Assertions::BundleIsUpToDate,
+      CreateGithubRelease::Assertions::InGitRepo,
+      CreateGithubRelease::Assertions::InRepoRootDirectory,
+      CreateGithubRelease::Assertions::OnDefaultBranch,
+      CreateGithubRelease::Assertions::NoUncommittedChanges,
+      CreateGithubRelease::Assertions::NoStagedChanges,
+      CreateGithubRelease::Assertions::LocalAndRemoteOnSameCommit,
+      CreateGithubRelease::Assertions::ReleaseTagDoesNotExist,
+      CreateGithubRelease::Assertions::ReleaseBranchDoesNotExist,
+      CreateGithubRelease::Assertions::DockerIsRunning,
+      CreateGithubRelease::Assertions::ChangelogDockerContainerExists,
+      CreateGithubRelease::Assertions::GhCommandExists
+    ].freeze
+
+    # Run all assertions
+    #
+    # @example
+    #   require 'create_github_release'
+    #
+    #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+    #   assertions = CreateGithubRelease::ReleaseAssertions.new(options)
+    #   assertions.make_assertions
+    #
+    # @return [void]
+    #
+    # @raises [SystemExit] if any assertion fails
+    #
+    def make_assertions
+      ASSERTIONS.each do |assertion_class|
+        assertion_class.new(options).assert
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertion_base_spec.rb
+++ b/spec/create_github_release/assertion_base_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::AssertionBase do
+  let(:assertion) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  describe '#assert' do
+    subject { assertion.assert }
+    it 'calling assert on an instance of AssertionBase should raise a NotImplementedError' do
+      expect { subject }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/create_github_release/assertions/bundle_is_up_to_date_spec.rb
+++ b/spec/create_github_release/assertions/bundle_is_up_to_date_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::BundleIsUpToDate do
+  let(:assertion) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    context 'when Gemfile.lock exists' do
+      before do
+        allow(File).to receive(:exist?).with('Gemfile.lock') { true }
+      end
+
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('bundle update --quiet', exitstatus: exitstatus)
+        ]
+      end
+
+      context 'when bundle update succeeds' do
+        let(:exitstatus) { 0 }
+        it 'should succeed' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when bundle update fails' do
+        let(:exitstatus) { 1 }
+        it 'should fail' do
+          expect { subject }.to raise_error(SystemExit)
+        end
+      end
+    end
+
+    context 'when Gemfile.lock DOES NOT exist' do
+      before do
+        allow(File).to receive(:exist?).with('Gemfile.lock') { false }
+      end
+
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('bundle install --quiet', exitstatus: exitstatus)
+        ]
+      end
+
+      context 'when bundle install succeeds' do
+        let(:exitstatus) { 0 }
+        it 'should succeed' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
+      context 'when bundle install fails' do
+        let(:exitstatus) { 1 }
+        it 'should fail' do
+          expect { subject }.to raise_error(SystemExit)
+        end
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/changelog_docker_container_exists_spec.rb
+++ b/spec/create_github_release/assertions/changelog_docker_container_exists_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::ChangelogDockerContainerExists do
+  let(:assertion) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new(/^docker build --file /, exitstatus: exitstatus)
+      ]
+    end
+
+    context 'when docker build succeeds' do
+      let(:exitstatus) { 0 }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when docker build fails' do
+      let(:exitstatus) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/docker_is_running_spec.rb
+++ b/spec/create_github_release/assertions/docker_is_running_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::DockerIsRunning do
+  let(:assertion) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new('docker info > /dev/null 2>&1', exitstatus: exitstatus)
+      ]
+    end
+
+    context 'when docker is running' do
+      let(:exitstatus) { 0 }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when docker is not running' do
+      let(:exitstatus) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/gh_command_exists_spec.rb
+++ b/spec/create_github_release/assertions/gh_command_exists_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::GhCommandExists do
+  let(:assertion) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new('which gh > /dev/null 2>&1', exitstatus: exitstatus)
+      ]
+    end
+
+    context 'when gh command exists' do
+      let(:exitstatus) { 0 }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when gh command does not exist' do
+      let(:exitstatus) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/in_git_repo_spec.rb
+++ b/spec/create_github_release/assertions/in_git_repo_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::InGitRepo do
+  let(:assertion) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new('git rev-parse --is-inside-work-tree --quiet > /dev/null 2>&1', exitstatus: exitstatus)
+      ]
+    end
+
+    context 'when in a git repo' do
+      let(:exitstatus) { 0 }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when not in a git repo' do
+      let(:exitstatus) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/in_repo_root_directory_spec.rb
+++ b/spec/create_github_release/assertions/in_repo_root_directory_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+RSpec.describe CreateGithubRelease::Assertions::InRepoRootDirectory do
+  let(:assertion) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    let(:current_directory) { '/current/directory' }
+
+    before do
+      allow(FileUtils).to receive(:pwd).and_return(current_directory)
+    end
+
+    context 'when in the repo root directory' do
+      let(:mocked_commands) { [MockedCommand.new('git rev-parse --show-toplevel', stdout: "#{current_directory}\n")] }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when NOT in the repo root directory' do
+      let(:mocked_commands) { [MockedCommand.new('git rev-parse --show-toplevel', stdout: "/other/directory\n")] }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the git command fails' do
+      let(:mocked_commands) { [MockedCommand.new('git rev-parse --show-toplevel', exitstatus: 1)] }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/local_and_remote_on_same_commit_spec.rb
+++ b/spec/create_github_release/assertions/local_and_remote_on_same_commit_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::LocalAndRemoteOnSameCommit do
+  let(:assertion) { described_class.new(options) }
+  let(:options) do
+    CreateGithubRelease::Options.new do |o|
+      o.release_type = 'major'
+      o.default_branch = 'default-branch'
+    end
+  end
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+    allow(options).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new(
+          'git rev-parse HEAD',
+          stdout: "#{local_commit}\n",
+          exitstatus: exitstatus
+        ),
+        MockedCommand.new(
+          "git ls-remote 'origin' 'default-branch' | cut -f 1",
+          stdout: "#{remote_commit}\n",
+          exitstatus: exitstatus
+        )
+      ]
+    end
+
+    context 'when the local and remote commits are the same' do
+      let(:exitstatus) { 0 }
+      let(:local_commit) { '976b79' }
+      let(:remote_commit) { '976b79' }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the local and remote commits are different' do
+      let(:exitstatus) { 0 }
+      let(:local_commit) { '976b79' }
+      let(:remote_commit) { '9535c0' }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/no_staged_changes_spec.rb
+++ b/spec/create_github_release/assertions/no_staged_changes_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::NoStagedChanges do
+  let(:assertion) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+    allow(options).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:git_command) { 'git diff --staged --name-only | wc -l' }
+
+    context 'when there are not staged changes' do
+      let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "0\n")] }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when there are staged changes' do
+      let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "99\n")] }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the git command fails' do
+      let(:mocked_commands) { [MockedCommand.new(git_command, exitstatus: 1)] }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/no_uncommitted_changes_spec.rb
+++ b/spec/create_github_release/assertions/no_uncommitted_changes_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::NoUncommittedChanges do
+  let(:assertion) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+    allow(options).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:git_command) { 'git status --porcelain | wc -l' }
+
+    context 'when there are NO uncommitted changes' do
+      let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "0\n")] }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when there are uncommitted changes' do
+      let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "99\n")] }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the git command fails' do
+      let(:mocked_commands) { [MockedCommand.new(git_command, exitstatus: 1)] }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/on_default_branch_spec.rb
+++ b/spec/create_github_release/assertions/on_default_branch_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::OnDefaultBranch do
+  let(:assertion) { described_class.new(options) }
+  let(:options) do
+    CreateGithubRelease::Options.new do |o|
+      o.release_type = 'major'
+      o.default_branch = 'default-branch'
+    end
+  end
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+    allow(options).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:git_command) { 'git branch --show-current' }
+
+    context 'when on the default branch' do
+      let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "default-branch\n")] }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when not on the default branch' do
+      let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "other-branch\n")] }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the git command fails' do
+      let(:mocked_commands) { [MockedCommand.new(git_command, exitstatus: 1)] }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/release_branch_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/release_branch_does_not_exist_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::ReleaseBranchDoesNotExist do
+  let(:assertion) { described_class.new(options) }
+  let(:options) do
+    CreateGithubRelease::Options.new do |o|
+      o.release_type = 'major'
+      o.branch = 'current-branch'
+    end
+  end
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+    allow(options).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:git_command) { 'git branch --show-current' }
+
+    context 'when NEITHER local NOR remote release branches exist' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git branch --list "current-branch" | wc -l', stdout: "0\n"),
+          MockedCommand.new(
+            "git ls-remote --heads --exit-code 'origin' 'current-branch' >/dev/null 2>&1", exitstatus: 1
+          )
+        ]
+      end
+
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the local release branch exists' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git branch --list "current-branch" | wc -l', stdout: "1\n"),
+          MockedCommand.new(
+            "git ls-remote --heads --exit-code 'origin' 'current-branch' >/dev/null 2>&1", exitstatus: 1
+          )
+        ]
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the remote release branch exists' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git branch --list "current-branch" | wc -l', stdout: "0\n"),
+          MockedCommand.new(
+            "git ls-remote --heads --exit-code 'origin' 'current-branch' >/dev/null 2>&1", exitstatus: 0
+          )
+        ]
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the local AND remote release branches exist' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git branch --list "current-branch" | wc -l', stdout: "1\n"),
+          MockedCommand.new(
+            "git ls-remote --heads --exit-code 'origin' 'current-branch' >/dev/null 2>&1", exitstatus: 0
+          )
+        ]
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the git command for the local release branch fails' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git branch --list "current-branch" | wc -l', exitstatus: 1),
+          MockedCommand.new(
+            "git ls-remote --heads --exit-code 'origin' 'current-branch' >/dev/null 2>&1", exitstatus: 1
+          )
+        ]
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertions/release_tag_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/release_tag_does_not_exist_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Assertions::ReleaseTagDoesNotExist do
+  let(:assertion) { described_class.new(options) }
+  let(:options) do
+    CreateGithubRelease::Options.new do |o|
+      o.release_type = 'major'
+      o.tag = 'v1.0.0'
+    end
+  end
+
+  before do
+    allow(assertion).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#assert' do
+    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:exist?).and_call_original
+    end
+
+    let(:git_command) { 'git branch --show-current' }
+
+    context 'when NEITHER local NOR remote release tags exist' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git tag --list "v1.0.0"'),
+          MockedCommand.new("git ls-remote --tags --exit-code 'origin' v1.0.0 >/dev/null 2>&1", exitstatus: 1)
+        ]
+      end
+
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the local release tag exists' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git tag --list "v1.0.0"', stdout: "v1.0.0\n"),
+          MockedCommand.new("git ls-remote --tags --exit-code 'origin' v1.0.0 >/dev/null 2>&1", exitstatus: 1)
+        ]
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the remote release tag exists' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git tag --list "v1.0.0"'),
+          MockedCommand.new("git ls-remote --tags --exit-code 'origin' v1.0.0 >/dev/null 2>&1", exitstatus: 0)
+        ]
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the local AND remote release tags exist' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git tag --list "v1.0.0"', stdout: "v1.0.0\n"),
+          MockedCommand.new("git ls-remote --tags --exit-code 'origin' v1.0.0 >/dev/null 2>&1", exitstatus: 0)
+        ]
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the git command for the local release tag fails' do
+      let(:mocked_commands) do
+        [
+          MockedCommand.new('git tag --list "v1.0.0"', exitstatus: 1),
+          MockedCommand.new("git ls-remote --tags --exit-code 'origin' v1.0.0 >/dev/null 2>&1", exitstatus: 1)
+        ]
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/release_assertions_spec.rb
+++ b/spec/create_github_release/release_assertions_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::ReleaseAssertions do
+  let(:release_assertions) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  describe '#make_assertions' do
+    subject { release_assertions.make_assertions }
+
+    let(:assertions) do
+      # Assume that all classes in the Assertions module are assertions
+      assertions_module = CreateGithubRelease::Assertions
+      assertions_module.constants.select { |c| assertions_module.const_get(c).is_a? Class }
+    end
+
+    before do
+      assertions_called = []
+      @assertions_called = assertions_called
+      assertions.each do |assertion|
+        assertion_class = CreateGithubRelease::Assertions.const_get(assertion)
+        expect(assertion_class).to receive(:new).with(options) do |_options|
+          Class.new do
+            @assertion = assertion
+            @assertions_called = assertions_called
+            def assert
+              self.class.instance_variable_get(:@assertions_called) << self.class.instance_variable_get(:@assertion)
+            end
+          end.new
+        end
+      end
+    end
+
+    it 'should instantiate and call assert on all assertions' do
+      subject
+      expect(@assertions_called).to match_array(assertions)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,49 @@ end
 
 SimpleCov.start
 
+# Helper class and method for mocking backtick calls
+
+class MockedCommand
+  def initialize(command, stdout: '', stderr: '', exitstatus: 0)
+    @command = command
+    @stdout = stdout
+    @stderr = stderr
+    @exitstatus = exitstatus
+  end
+
+  attr_reader :command, :stdout, :stderr, :exitstatus
+end
+
+def execute_mocked_command(mocked_commands, command)
+  mocked_command = mocked_commands.find { |c| c.command.match(command) }
+  raise "Command '#{command}' was not mocked" unless mocked_command
+
+  `exit #{mocked_command.exitstatus}`
+  mocked_command.stdout
+end
+
+# Captures stdout and stderr output from a block of code
+#
+# @example
+#   stdout, stderr = capture_output { puts 'hello'; warn 'world' }
+#   stdout # => "hello\n"
+#   stderr # => "world\n"
+#
+# @example Used to test an assertion
+#   subject { @stdout, @stderr = capture_output { assertion.assert } }
+#
+# @return [Array<String, String>] stdout and stderr output
+#
+def capture_output(&block)
+  $stdout = StringIO.new
+  $stderr = StringIO.new
+  block.call
+  [$stdout.string, $stderr.string]
+ensure
+  $stdout = STDOUT
+  $stderr = STDERR
+end
+
 # Make sure to require your project AFTER SimpleCov.start
 #
 require 'create_github_release'


### PR DESCRIPTION
Add checks for everything that must be "true" for a release to be created. This includes the following checks:
1. Bundle is up to date
2. Docker is running
3. the changelog docker container exists
4. the gh command is in the path
5. the release is being done from the root directory of a git working copy
6. there are no staged or uncommitted changes
7. the default branch is checked out
8. the release branch and tag does not exist in the local or remote repository

Run all the assertions as follows:
```ruby
require 'create_github_release'

options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
assertions = CreateGithubRelease::ReleaseAssertions.new(options)
assertions.make_assertions
```