### PR TITLE
Add release tasks

### DIFF
--- a/lib/create_github_release.rb
+++ b/lib/create_github_release.rb
@@ -2,15 +2,17 @@
 
 require 'create_github_release/command_line_parser'
 
+require 'create_github_release/changelog'
 require 'create_github_release/options'
+require 'create_github_release/release'
 
 require 'create_github_release/assertion_base'
 require 'create_github_release/assertions'
 require 'create_github_release/release_assertions'
 
-# require 'create_github_release/task_base'
-# require 'create_github_release/tasks'
-# require 'create_github_release/release_tasks'
+require 'create_github_release/task_base'
+require 'create_github_release/tasks'
+require 'create_github_release/release_tasks'
 
 require 'create_github_release/version'
 

--- a/lib/create_github_release/assertions.rb
+++ b/lib/create_github_release/assertions.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+module CreateGithubRelease
+  # Assertions used to validate that everything is ready to create the release
+  #
+  # @api public
+  #
+  module Assertions; end
+end
+
 require_relative 'assertions/bundle_is_up_to_date'
 require_relative 'assertions/changelog_docker_container_exists'
 require_relative 'assertions/docker_is_running'

--- a/lib/create_github_release/assertions/gh_command_exists.rb
+++ b/lib/create_github_release/assertions/gh_command_exists.rb
@@ -7,8 +7,6 @@ module CreateGithubRelease
   module Assertions
     # Assert that the 'gh' command is in the path
     #
-    # Checks both the local repository and the remote repository.
-    #
     # @api public
     #
     class GhCommandExists < AssertionBase

--- a/lib/create_github_release/assertions/in_repo_root_directory.rb
+++ b/lib/create_github_release/assertions/in_repo_root_directory.rb
@@ -34,6 +34,8 @@ module CreateGithubRelease
       def assert
         print "Checking that you are in the repo's root directory..."
         toplevel_directory = `git rev-parse --show-toplevel`.chomp
+        error "git rev-parse failed: #{$CHILD_STATUS.exitstatus}" unless $CHILD_STATUS.success?
+
         if toplevel_directory == FileUtils.pwd
           puts 'OK'
         else

--- a/lib/create_github_release/assertions/no_staged_changes.rb
+++ b/lib/create_github_release/assertions/no_staged_changes.rb
@@ -32,7 +32,10 @@ module CreateGithubRelease
       #
       def assert
         print 'Checking that there are no staged changes...'
-        if `git diff --staged --name-only | wc -l`.to_i.zero? && $CHILD_STATUS.success?
+        change_count = `git diff --staged --name-only | wc -l`.to_i
+        error "git diff command failed: #{$CHILD_STATUS.exitstatus}" unless $CHILD_STATUS.success?
+
+        if change_count.zero?
           puts 'OK'
         else
           error 'There are staged changes'

--- a/lib/create_github_release/assertions/no_uncommitted_changes.rb
+++ b/lib/create_github_release/assertions/no_uncommitted_changes.rb
@@ -32,7 +32,10 @@ module CreateGithubRelease
       #
       def assert
         print 'Checking that there are no uncommitted changes...'
-        if `git status --porcelain | wc -l`.to_i.zero? && $CHILD_STATUS.success?
+        change_count = `git status --porcelain | wc -l`.to_i
+        error "git status command failed: #{$CHILD_STATUS.exitstatus}" unless $CHILD_STATUS.success?
+
+        if change_count.zero?
           puts 'OK'
         else
           error 'There are uncommitted changes'

--- a/lib/create_github_release/changelog.rb
+++ b/lib/create_github_release/changelog.rb
@@ -1,0 +1,372 @@
+# frozen_string_literal: true
+
+module CreateGithubRelease
+  # Generate a changelog for a new release
+  #
+  # Given an existing changelog and a description of a new release, generate a
+  # new changelog that includes the new release.
+  #
+  # @api public
+  #
+  class Changelog
+    # Create a new changelog object
+    #
+    # @example
+    #   existing_changelog = <<~EXISTING_CHANGELOG.chomp
+    #     # Change Log
+    #
+    #     List of changes in each release of this project.
+    #
+    #     ## v0.1.0 (2022-10-31)
+    #
+    #     * 07a1167 Release v0.1.0 (#1)
+    #   EXISTING_CHANGELOG
+    #
+    #   new_release_tag = 'v1.0.0'
+    #   new_release_date = Date.parse('2022-11-10')
+    #   new_release_description = <<~RELEASE
+    #     * f5e69d6 Release v1.0.0 (#4)
+    #     * 8fe479b Update documentation for initial GA release (#3)
+    #   RELEASE
+    #
+    #   new_release = CreateGithubRelease::Release.new(new_release_tag, new_release_date, new_release_description)
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(existing_changelog, new_release)
+    #
+    #   expected_new_changelog = <<~CHANGELOG
+    #     # Change Log
+    #
+    #     List of changes in each release of this project.
+    #
+    #     ## v1.0.0 (2022-11-10)
+    #
+    #     * f5e69d6 Release v1.0.0 (#4)
+    #     * 8fe479b Update documentation for initial GA release (#3)
+    #
+    #     ## v0.1.0 (2022-10-31)
+    #
+    #     * 07a1167 Release v0.1.0 (#1)
+    #   CHANGELOG
+    #
+    #   changelog.front_matter # =>  "# Change Log\n\nList of changes in each release of this project."
+    #   changelog.body # => "## v0.1.0 (2022-10-31)\n\n* 07a1167 Release v0.1.0 (#1)"
+    #   changelog.new_release # => #<CreateGithubRelease::Release:0x000000010761aac8 ...>
+    #   changelog.to_s == expected_new_changelog # => true
+    #
+    # @param existing_changelog [String] Contents of the changelog as a string
+    # @param new_release [CreateGihubRelease::Release] The new release to add to the changelog
+    #
+    def initialize(existing_changelog, new_release)
+      @existing_changelog = existing_changelog
+      @new_release = new_release
+
+      @lines = existing_changelog.lines.map(&:chomp)
+    end
+
+    # The front matter of the changelog
+    #
+    # This is the part of the changelog up until the body. The body contains the list
+    # of releases and is the first line starting with '## '.
+    #
+    # @example Changelog with front matter
+    #   changelog_text = <<~CHANGELOG
+    #     This is the front matter
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new('v0.1.0', Date.today, '...')
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #   changelog.front_matter # => "This is the front matter\n"
+    #
+    # @example Changelog without front matter
+    #   changelog_text = <<~CHANGELOG
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new('v0.1.0', Date.today, '...')
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #   changelog.front_matter # => ""
+    #
+    # @example An empty changelog
+    #   changelog_text = <<~CHANGELOG
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new('v0.1.0', Date.today, '...')
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #   changelog.front_matter # => ""
+    #
+    # @example An empty changelog
+    #   changelog_text = ""
+    #
+    #   new_release = CreateGithubRelease::Release.new('v0.1.0', Date.today, '...')
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #   changelog.front_matter # => ""
+    #
+    # @return [String] The front matter of the changelog
+    def front_matter
+      return '' if front_matter_start == front_matter_end
+
+      lines[front_matter_start..front_matter_end - 1].join("\n")
+    end
+
+    # The body of the existing changelog
+    #
+    # @example Changelog with front matter and a body
+    #   changelog_text = <<~CHANGELOG
+    #     This is the front matter
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new('v0.1.0', Date.today, '...')
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #   changelog.body # => "## v0.1.0\n..."
+    #
+    # @example Changelog without front matter
+    #   changelog_text = <<~CHANGELOG
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new('v0.1.0', Date.today, '...')
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #   changelog.body # => "## v0.1.0\n..."
+    #
+    # @example Changelog without a body
+    #   changelog_text = <<~CHANGELOG
+    #     This is the front matter
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new('v0.1.0', Date.today, '...')
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #   changelog.body # => ""
+    #
+    # @example An empty changelog (new line only)
+    #   changelog_text = <<~CHANGELOG
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new('v0.1.0', Date.today, '...')
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #   changelog.body # => ""
+    #
+    # @example An empty changelog (empty string)
+    #   changelog_text = ""
+    #
+    #   new_release = CreateGithubRelease::Release.new('v0.1.0', Date.today, '...')
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #   changelog.body # => ""
+    #
+    # @return [String] The body of the existing changelog
+    #
+    def body
+      return '' if body_start == body_end
+
+      lines[body_start..body_end - 1].join("\n")
+    end
+
+    # The changelog before the new release is added
+    #
+    # @example
+    #   changelog.existing_changelog # => "# Change Log\n\n## v1.0.0...## v0.1.0...\n"
+    #
+    # @return [String] The changelog before the new release is added
+    #
+    attr_reader :existing_changelog
+
+    # The new release to add to the changelog
+    #
+    # @example
+    #   changelog.new_release.tag # => 'v1.0.0'
+    #   changelog.new_release.date # => #<Date: 2018-06-30>
+    #   changelog.new_release.description # => "[Full Changelog](...)..."
+    #
+    # @return [CreateGithubRelease::Release] The new release to add to the changelog
+    #
+    attr_reader :new_release
+
+    # The changelog with the new release
+    #
+    # @example Changelog with front matter and a body
+    #   changelog_text = <<~CHANGELOG
+    #     This is the front matter
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new(
+    #     'v1.0.0', Date.parse('2022-11-08'), '...release description...'
+    #   )
+    #
+    #   expected_changelog = <<~CHANGELOG
+    #     This is the front matter
+    #
+    #     ## v1.0.0 (2022-11-08)
+    #     ...release description...
+    #
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #
+    #   changelog.to_s == expected_changelog # => true
+    #
+    # @example Changelog without front matter
+    #   changelog_text = <<~CHANGELOG
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new(
+    #     'v1.0.0', Date.parse('2022-11-08'), '...release description...'
+    #   )
+    #
+    #   expected_changelog = <<~CHANGELOG
+    #     ## v1.0.0 (2022-11-08)
+    #     ...release description...
+    #
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #
+    #   changelog.to_s == expected_changelog # => true
+    #
+    # @example Changelog without a body
+    #   changelog_text = <<~CHANGELOG
+    #     This is the front matter
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new(
+    #     'v1.0.0', Date.parse('2022-11-08'), '...release description...'
+    #   )
+    #
+    #   expected_changelog = <<~CHANGELOG
+    #     This is the front matter
+    #
+    #     ## v1.0.0 (2022-11-08)
+    #     ...release description...
+    #   CHANGELOG
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #
+    #   changelog.to_s == expected_changelog # => true
+    #
+    # @example A new release without a description
+    #   changelog_text = <<~CHANGELOG
+    #     This is the front matter
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   new_release = CreateGithubRelease::Release.new(
+    #     'v1.0.0', Date.parse('2022-11-08'), ''
+    #   )
+    #
+    #   expected_changelog = <<~CHANGELOG
+    #     This is the front matter
+    #
+    #     ## v1.0.0 (2022-11-08)
+    #
+    #     ## v0.1.0
+    #     ...
+    #   CHANGELOG
+    #
+    #   changelog = CreateGithubRelease::Changelog.new(changelog_text, new_release)
+    #
+    #   changelog.to_s == expected_changelog # => true
+    #
+    # @return [String] The changelog with the new release details
+    #
+    def to_s
+      String.new.tap do |changelog|
+        changelog << "#{front_matter}\n\n" unless front_matter.empty?
+        changelog << release_header
+        changelog << release_description
+        changelog << "\n#{body}\n" unless body.empty?
+      end
+    end
+
+    private
+
+    # The index of the line in @lines where the front matter begins
+    # @return [Integer] The index of the line in @lines where the front matter begins
+    # @api private
+    def front_matter_start
+      @front_matter_start ||= begin
+        i = 0
+        i += 1 while i < body_start && lines[i] =~ /^\s*$/
+        i
+      end
+    end
+
+    # One past the index of the line in @lines where the front matter ends
+    # @return [Integer] One past the index of the line in @lines where the front matter ends
+    # @api private
+    def front_matter_end
+      @front_matter_end ||= begin
+        i = body_start
+        i -= 1 while i.positive? && lines[i - 1] =~ /^\s*$/
+        i
+      end
+    end
+
+    # The index of the line in @lines where the body begins
+    # @return [Integer] The index of the line in @lines where the body begins
+    # @api private
+    def body_start
+      @body_start ||=
+        lines.index { |l| l.start_with?('## ') } || lines.length
+    end
+
+    # One past the index of the line in @lines where the body ends
+    # @return [Integer] One past the index of the line in @lines where the body ends
+    # @api private
+    def body_end
+      @body_end ||=
+        if body_start == lines.length
+          body_start
+        else
+          i = lines.length
+          i -= 1 while i > body_start && lines[i - 1] =~ /^\s*$/
+          i
+        end
+    end
+
+    # The release header to output in the changelog
+    # @return [String] The release header to output in the changelog
+    # @api private
+    def release_header
+      "## #{new_release.tag} (#{new_release.date.strftime('%Y-%m-%d')})\n"
+    end
+
+    # The release description to output in the changelog
+    # @return [String] The release description to output in the changelog
+    # @api private
+    def release_description
+      new_release.description.empty? ? '' : "\n#{new_release.description.chomp}\n"
+    end
+
+    # Line number where the body of the changelog starts
+    # @return [Integer] Line number where the body of the changelog starts
+    # @api private
+    # attr_reader :body_start
+
+    # The existing changelog broken into an array of lines
+    # @return [Array<String>] The existing changelog broken into an array of lines
+    # @api private
+    attr_reader :lines
+  end
+end

--- a/lib/create_github_release/release.rb
+++ b/lib/create_github_release/release.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module CreateGithubRelease
+  # The release information needed to generate a changelog
+  #
+  # @api public
+  #
+  class Release
+    # Create a new release object
+    #
+    # @example
+    #   tag = 'v0.1.1'
+    #   date = Date.new(2022, 11, 7)
+    #   description = <<~DESCRIPTION
+    #     * e718690 Release v0.1.1 (#3)
+    #     * a92453c Bug fix (#2)
+    #   DESCRIPTION
+    #
+    #   release = CreateGithubRelease::Release.new(tag, date, description)
+    #   release.tag # => 'v0.1.1'
+    #   release.date # => #<Date: 2022-11-07 ((2459773j,0s,0n),+0s,2299161j)>
+    #   release.description # => "* e718690 Release v0.1.1 (#3)\n* a92453c Bug fix (#2)\n"
+    #
+    # @param tag [String] The tag of the release
+    # @param date [Date] The date of the release
+    # @param description [String] The description of the release (usually a bullet list of changes)
+    #
+    def initialize(tag, date, description)
+      @tag = tag
+      @date = date
+      @description = description
+    end
+
+    # The Git release tag
+    #
+    # @example
+    #   tag = 'v0.1.1'
+    #   date = Date.new(2022, 11, 7)
+    #   description = <<~DESCRIPTION
+    #     * e718690 Release v0.1.1 (#3)
+    #     * a92453c Bug fix (#2)
+    #   DESCRIPTION
+    #
+    #   release = CreateGithubRelease::Release.new(tag, date, description)
+    #   release.tag # => 'v0.1.1'
+    #
+    # @return [String] The Git release tag
+    attr_reader :tag
+
+    # The date the release tag was created
+    #
+    # @example
+    #   tag = 'v0.1.1'
+    #   date = Date.new(2022, 11, 7)
+    #   description = <<~DESCRIPTION
+    #     * e718690 Release v0.1.1 (#3)
+    #     * a92453c Bug fix (#2)
+    #   DESCRIPTION
+    #
+    #   release = CreateGithubRelease::Release.new(tag, date, description)
+    #   release.date # => #<Date: 2022-11-07 ((2459773j,0s,0n),+0s,2299161j)>
+    #
+    # @return [Date] The date the release tag was created
+    attr_reader :date
+
+    # The description of the release
+    #
+    # @example
+    #   tag = 'v0.1.1'
+    #   date = Date.new(2022, 11, 7)
+    #   description = <<~DESCRIPTION
+    #     * e718690 Release v0.1.1 (#3)
+    #     * a92453c Bug fix (#2)
+    #   DESCRIPTION
+    #
+    #   release = CreateGithubRelease::Release.new(tag, date, description)
+    #   release.description # => "* e718690 Release v0.1.1 (#3)\n* a92453c Bug fix (#2)\n"
+    #
+    # @return [String] The description of the release
+    attr_reader :description
+  end
+end

--- a/lib/create_github_release/release_assertions.rb
+++ b/lib/create_github_release/release_assertions.rb
@@ -40,6 +40,12 @@ module CreateGithubRelease
       @options = options
     end
 
+    # The assertions that must be true for a new Github release to be created
+    #
+    # The assertions are run in the order they are defined in this array.
+    #
+    # @return [Array<Class>] The assertions that must be true for a new Github release to be created
+    #
     ASSERTIONS = [
       CreateGithubRelease::Assertions::GitCommandExists,
       CreateGithubRelease::Assertions::BundleIsUpToDate,
@@ -69,7 +75,7 @@ module CreateGithubRelease
     #
     # @return [void]
     #
-    # @raises [SystemExit] if any assertion fails
+    # @raise [SystemExit] if any assertion fails
     #
     def make_assertions
       ASSERTIONS.each do |assertion_class|

--- a/lib/create_github_release/release_tasks.rb
+++ b/lib/create_github_release/release_tasks.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'create_github_release/tasks'
+
+module CreateGithubRelease
+  # Tasks that must be run to create a new Github release.
+  #
+  # @example
+  #   require 'create_github_release'
+  #
+  #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+  #   tasks = CreateGithubRelease::ReleaseTasks.new(options)
+  #   tasks.run
+  #
+  # @api public
+  #
+  class ReleaseTasks
+    # The options used to create the Github release
+    #
+    # @example
+    #   require 'create_github_release'
+    #
+    #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+    #   tasks = CreateGithubRelease::ReleaseTasks.new(options)
+    #   tasks.options # => #<CreateGithubRelease::Options:0x00007f9b0a0b0a00>
+    #
+    # @return [CreateGithubRelease::Options]
+    attr_reader :options
+
+    # Create a new instance of ReleaseTasks
+    #
+    # @example
+    #   require 'create_github_release'
+    #
+    #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+    #   tasks = CreateGithubRelease::ReleaseTasks.new(options)
+    #   tasks.run
+    #
+    def initialize(options)
+      @options = options
+    end
+    # The tasks that will be run to create a new Github release
+    #
+    # The tasks are run in the order they are defined in this array.
+    #
+    # @return [Array<Class>] The tasks that will be run to create a new Github release
+    #
+    TASKS = [
+      CreateGithubRelease::Tasks::CreateReleaseBranch,
+      CreateGithubRelease::Tasks::UpdateChangelog,
+      CreateGithubRelease::Tasks::UpdateVersion,
+      CreateGithubRelease::Tasks::CommitRelease,
+      CreateGithubRelease::Tasks::CreateReleaseTag,
+      CreateGithubRelease::Tasks::PushRelease,
+      CreateGithubRelease::Tasks::CreateGithubRelease,
+      CreateGithubRelease::Tasks::CreateReleasePullRequest
+    ].freeze
+
+    # Run all tasks to create a new Github release
+    #
+    # @example
+    #   require 'create_github_release'
+    #
+    #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+    #   tasks = CreateGithubRelease::ReleaseTasks.new(options)
+    #   tasks.run
+    #
+    # @return [void]
+    #
+    # @raise [SystemExit] if any task fails
+    #
+    def run
+      TASKS.each do |task_class|
+        task_class.new(options).run
+      end
+    end
+  end
+end

--- a/lib/create_github_release/task_base.rb
+++ b/lib/create_github_release/task_base.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module CreateGithubRelease
+  # Base class for tasks
+  #
+  # All tasks must inherit from this class.
+  # It holds the options and knows how to print, puts and error while respecting the `quiet` flag.
+  #
+  # @api private
+  #
+  class TaskBase
+    # Create a new tasks object and save the given `options`
+    # @param options [CreateGithubRelease::Options] the options
+    # @api private
+    def initialize(options)
+      @options = options
+    end
+
+    # This method must be overriden by a subclass
+    #
+    # The subclass is expected to call `error` if the task fails.
+    #
+    # @return [void]
+    #
+    # @api private
+    def run
+      raise NotImplementedError
+    end
+
+    # @!attribute [r] options
+    #
+    # The options passed to the task object
+    # @return [CreateGithubRelease::Options] the options
+    # @api private
+    attr_reader :options
+
+    # Calls `Kernel.print` if the `quiet` flag is not set in the `options`
+    # @param args [Array] the arguments to pass to `Kernel.print`
+    # @return [void]
+    # @api private
+    def print(*args)
+      super unless options.quiet
+    end
+
+    # Calls `Kernel.puts` if the `quiet` flag is not set in the `options`
+    # @param args [Array] the arguments to pass to `Kernel.puts`
+    # @return [void]
+    # @api private
+    def puts(*args)
+      super unless options.quiet
+    end
+
+    # Writes a message to stderr and exits with exitcode 1
+    # @param message [String] the message to write to stderr
+    # @return [void]
+    # @api private
+    def error(message)
+      warn "ERROR: #{message}"
+      exit 1
+    end
+  end
+end

--- a/lib/create_github_release/tasks.rb
+++ b/lib/create_github_release/tasks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CreateGithubRelease
+  # Tasks/commands used to creat the Github release
+  #
+  # @api public
+  #
+  module Tasks; end
+end
+
+require_relative 'tasks/commit_release'
+require_relative 'tasks/create_github_release'
+require_relative 'tasks/create_release_branch'
+require_relative 'tasks/create_release_pull_request'
+require_relative 'tasks/create_release_tag'
+require_relative 'tasks/push_release'
+require_relative 'tasks/update_changelog'
+require_relative 'tasks/update_version'

--- a/lib/create_github_release/tasks/commit_release.rb
+++ b/lib/create_github_release/tasks/commit_release.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'create_github_release/task_base'
+
+module CreateGithubRelease
+  module Tasks
+    # Commit the files added for the release
+    #
+    # @api public
+    #
+    class CommitRelease < TaskBase
+      # Commit the files added for the release
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   task = CreateGithubRelease::Tasks::CommitRelease.new(options)
+      #   begin
+      #     task.run
+      #     puts 'Task completed successfully'
+      #   rescue SystemExit
+      #     puts 'Task failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the task fails
+      #
+      def run
+        print 'Making release commit...'
+        `git commit -s -m 'Release #{options.tag}'`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'Could not make release commit'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/tasks/create_github_release.rb
+++ b/lib/create_github_release/tasks/create_github_release.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'create_github_release/task_base'
+require 'tempfile'
+
+module CreateGithubRelease
+  module Tasks
+    # Create the release in Github
+    #
+    # @api public
+    #
+    class CreateGithubRelease < TaskBase
+      # Create the release in Github
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   task = CreateGithubRelease::Tasks::CreateGithubRelease.new(options)
+      #   begin
+      #     task.run
+      #     puts 'Task completed successfully'
+      #   rescue SystemExit
+      #     puts 'Task failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the task fails
+      #
+      def run
+        path = write_changelog_to_temp_file(generate_changelog)
+        begin
+          create_github_release(path)
+        ensure
+          File.unlink(path)
+        end
+      end
+
+      private
+
+      # Create the gh command to create the Github release
+      # @return [String] the command to run
+      # @api private
+      def gh_command(default_branch, tag, changelog_path)
+        "gh release create '#{tag}' " \
+          "--title 'Release #{tag}' " \
+          "--notes-file '#{changelog_path}' " \
+          "--target '#{default_branch}'"
+      end
+
+      # Create the Github release using the gh command
+      # @return [void]
+      # @raise [SystemExit] if the gh command fails
+      # @api private
+      def create_github_release(changelog_path)
+        print "Creating GitHub release '#{options.tag}'..."
+        `#{gh_command(options.default_branch, options.tag, changelog_path)}`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'Could not create release'
+        end
+      end
+
+      # Writes the changelog to a temporary file
+      # @return [void]
+      # @raise [SystemExit] if a temp file could not be created
+      # @api private
+      def write_changelog_to_temp_file(changelog)
+        begin
+          f = Tempfile.create
+        rescue StandardError => e
+          error "Could not create a temporary file: #{e.message}"
+        end
+        f.write(changelog)
+        f.close
+        f.path
+      end
+
+      # Build the command that generates the description of the new release
+      # @return [String] the command to run
+      # @api private
+      def docker_command(git_dir, from_tag, to_tag)
+        "docker run --rm --volume '#{git_dir}:/worktree' changelog-rs '#{from_tag}' '#{to_tag}'"
+      end
+
+      # Generate the description of the new release using docker
+      # @return [void]
+      # @raise [SystemExit] if the docker command fails
+      # @api private
+      def generate_changelog
+        print 'Generating changelog...'
+        command = docker_command(FileUtils.pwd, options.current_tag, options.next_tag)
+        `#{command}`.rstrip.lines[1..].join.tap do
+          if $CHILD_STATUS.success?
+            puts 'OK'
+          else
+            error 'Could not generate the changelog'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/tasks/create_release_branch.rb
+++ b/lib/create_github_release/tasks/create_release_branch.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'create_github_release/task_base'
+
+module CreateGithubRelease
+  module Tasks
+    # Create the release branch in git
+    #
+    # @api public
+    #
+    class CreateReleaseBranch < TaskBase
+      # Create the release branch in git
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   task = CreateGithubRelease::Tasks::CreateReleaseBranch.new(options)
+      #   begin
+      #     task.run
+      #     puts 'Task completed successfully'
+      #   rescue SystemExit
+      #     puts 'Task failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the task fails
+      #
+      def run
+        print "Creating branch '#{options.branch}'..."
+        `git checkout -b '#{options.branch}' > /dev/null 2>&1`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error "Could not create branch '#{options.branch}'" unless $CHILD_STATUS.success?
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/tasks/create_release_pull_request.rb
+++ b/lib/create_github_release/tasks/create_release_pull_request.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'create_github_release/task_base'
+
+module CreateGithubRelease
+  module Tasks
+    # Create a pull request in Github with a list of changes
+    #
+    # @api public
+    #
+    class CreateReleasePullRequest < TaskBase
+      # Create a pull request in Github with a list of changes
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   task = CreateGithubRelease::Tasks::CreateReleasePullRequest.new(options)
+      #   begin
+      #     task.run
+      #     puts 'Task completed successfully'
+      #   rescue SystemExit
+      #     puts 'Task failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the task fails
+      #
+      def run
+        path = write_pr_body_to_temp_file(generate_changelog)
+        begin
+          create_release_pr(path)
+        ensure
+          File.unlink(path)
+        end
+      end
+
+      private
+
+      # Create the Github pull request using the gh command
+      # @return [void]
+      # @raise [SystemExit] if the gh command fails
+      # @api private
+      def create_release_pr(path)
+        print 'Creating GitHub pull request...'
+        tag = options.tag
+        default_branch = options.default_branch
+        `gh pr create --title 'Release #{tag}' --body-file '#{path}' --base '#{default_branch}'`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'Could not create release pull request'
+        end
+      end
+
+      # The body of the pull request
+      # @return [String] the body of the pull request
+      # @api private
+      def pr_body(changelog)
+        <<~BODY.chomp
+          ## Change Log
+          #{changelog}
+        BODY
+      end
+
+      # Write the changelog to a new temporary file
+      # @return [String] the path to the temporary file
+      # @raise [SystemExit] if the temp could not be created
+      # @api private
+      def write_pr_body_to_temp_file(changelog)
+        begin
+          f = Tempfile.create
+        rescue StandardError => e
+          error "Could not create a temporary file: #{e.message}"
+        end
+        f.write(pr_body(changelog))
+        f.close
+        f.path
+      end
+
+      # The command to list the changes in the relese
+      # @return [String] the command to run
+      # @api private
+      def docker_command(git_dir, from_tag, to_tag)
+        "docker run --rm --volume '#{git_dir}:/worktree' changelog-rs '#{from_tag}' '#{to_tag}'"
+      end
+
+      # Generate the list of changes in the release using docker
+      # @return [String] the list of changes
+      # @raise [SystemExit] if the docker command fails
+      # @api private
+      def generate_changelog
+        print 'Generating changelog...'
+        command = docker_command(FileUtils.pwd, options.current_tag, options.next_tag)
+        `#{command}`.rstrip.lines[1..].join.tap do
+          if $CHILD_STATUS.success?
+            puts 'OK'
+          else
+            error 'Could not generate the changelog'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/tasks/create_release_tag.rb
+++ b/lib/create_github_release/tasks/create_release_tag.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'create_github_release/task_base'
+
+module CreateGithubRelease
+  module Tasks
+    # Create a release tag in git
+    #
+    # @api public
+    #
+    class CreateReleaseTag < TaskBase
+      # Create a release tag in git
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   task = CreateGithubRelease::Tasks::CreateReleaseTag.new(options)
+      #   begin
+      #     task.run
+      #     puts 'Task completed successfully'
+      #   rescue SystemExit
+      #     puts 'Task failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the task fails
+      #
+      def run
+        print "Creating tag '#{options.tag}'..."
+        `git tag '#{options.tag}'`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error "Could not create tag '#{options.tag}'"
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/tasks/push_release.rb
+++ b/lib/create_github_release/tasks/push_release.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'create_github_release/task_base'
+
+module CreateGithubRelease
+  module Tasks
+    # Push the release branch and tag to Github
+    #
+    # @api public
+    #
+    class PushRelease < TaskBase
+      # Push the release branch and tag to Github
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   task = CreateGithubRelease::Tasks::PushRelease.new(options)
+      #   begin
+      #     task.run
+      #     puts 'Task completed successfully'
+      #   rescue SystemExit
+      #     puts 'Task failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the task fails
+      #
+      def run
+        print "Pushing branch '#{options.branch}' to remote..."
+        `git push --tags --set-upstream '#{options.remote}' '#{options.branch}' > /dev/null 2>&1`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'Could not push release commit'
+        end
+      end
+    end
+  end
+end

--- a/lib/create_github_release/tasks/update_changelog.rb
+++ b/lib/create_github_release/tasks/update_changelog.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'create_github_release/task_base'
+
+module CreateGithubRelease
+  module Tasks
+    # Update the changelog file with changes made since the last release
+    #
+    # @api public
+    #
+    class UpdateChangelog < TaskBase
+      # Update the changelog file with changes made since the last release
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   task = CreateGithubRelease::Tasks::UpdateChangelog.new(options)
+      #   begin
+      #     task.run
+      #     puts 'Task completed successfully'
+      #   rescue SystemExit
+      #     puts 'Task failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the task fails
+      #
+      def run
+        current_tag = options.current_tag
+        next_tag = options.next_tag
+        next_tag_date = next_tag_date(next_tag)
+        new_release = new_release(current_tag, next_tag, next_tag_date)
+        update_changelog(existing_changelog, new_release)
+        stage_updated_changelog
+      end
+
+      private
+
+      # Add the updated changelog to the git staging area
+      # @return [void]
+      # @raise [SystemExit] if the git command fails
+      # @api private
+      def stage_updated_changelog
+        print 'Staging CHANGLOG.md...'
+
+        `git add CHANGELOG.md`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'Could not stage changes to CHANGELOG.md'
+        end
+      end
+
+      # Read the existing changelog file
+      # @return [String] the contents of the changelog file
+      # @raise [SystemExit] if the file cannot be read
+      # @api private
+      def existing_changelog
+        @existing_changelog ||= begin
+          File.read('CHANGELOG.md')
+        rescue Errno::ENOENT
+          ''
+        end
+      end
+
+      # Find the date the release tag was created using git
+      # @return [Date] the date the release tag was created
+      # @raise [SystemExit] if the git command fails
+      # @api private
+      def next_tag_date(next_tag)
+        @next_tag_date ||= begin
+          print "Determining date #{next_tag} was created..."
+          date = `git show --format=format:%aI --quiet "#{next_tag}"`
+          if $CHILD_STATUS.success?
+            puts 'OK'
+            Date.parse(date)
+          else
+            error 'Could not stage changes to CHANGELOG.md'
+          end
+        end
+      end
+
+      # Build the command to list the changes since the last release
+      # @return [String] the command to list the changes since the last release
+      # @api private
+      def docker_command(git_dir, from_tag, to_tag)
+        "docker run --rm --volume '#{git_dir}:/worktree' changelog-rs '#{from_tag}' '#{to_tag}'"
+      end
+
+      # Generate the new release section of the changelog
+      # @return [CreateGithubRelease::Release] the new release section of the changelog
+      # @raise [SystemExit] if the docker command fails
+      # @api private
+      def new_release(current_tag, next_tag, next_tag_date)
+        print 'Generating release notes...'
+        command = docker_command(FileUtils.pwd, current_tag, next_tag)
+        release_description = `#{command}`.rstrip.lines[1..].join
+        if $CHILD_STATUS.success?
+          puts 'OK'
+          ::CreateGithubRelease::Release.new(next_tag, next_tag_date, release_description)
+        else
+          error 'Could not generate the release notes'
+        end
+      end
+
+      # Update the changelog file with the changes since the last release
+      # @return [void]
+      # @raise [SystemExit] if the file cannot be written
+      # @api private
+      def update_changelog(existing_changelog, new_release)
+        print 'Updating CHANGELOG.md...'
+        changelog = ::CreateGithubRelease::Changelog.new(existing_changelog, new_release)
+        begin
+          File.write('CHANGELOG.md', changelog.to_s)
+        rescue StandardError => e
+          error "Could not write to CHANGELOG.md: #{e.message}"
+        end
+        puts 'OK'
+      end
+    end
+  end
+end

--- a/lib/create_github_release/tasks/update_version.rb
+++ b/lib/create_github_release/tasks/update_version.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'create_github_release/task_base'
+
+module CreateGithubRelease
+  module Tasks
+    # Update the gem version using Bump
+    #
+    # @api public
+    #
+    class UpdateVersion < TaskBase
+      # Update the gem version using Bump
+      #
+      # @example
+      #   require 'create_github_release'
+      #
+      #   options = CreateGithubRelease::Options.new { |o| o.release_type = 'major' }
+      #   task = CreateGithubRelease::Tasks::UpdateVersion.new(options)
+      #   begin
+      #     task.run
+      #     puts 'Task completed successfully'
+      #   rescue SystemExit
+      #     puts 'Task failed'
+      #   end
+      #
+      # @return [void]
+      #
+      # @raise [SystemExit] if the task fails
+      #
+      def run
+        print 'Updating version...'
+        _next_version, result = Bump::Bump.run(options.release_type, commit: false)
+        error 'Could not bump version' unless result.zero?
+        `git add lib/git/version.rb`
+        if $CHILD_STATUS.success?
+          puts 'OK'
+        else
+          error 'Could not stage changes to lib/git/version.rb'
+        end
+      end
+    end
+  end
+end

--- a/spec/create_github_release/assertion_base_spec.rb
+++ b/spec/create_github_release/assertion_base_spec.rb
@@ -10,4 +10,9 @@ RSpec.describe CreateGithubRelease::AssertionBase do
       expect { subject }.to raise_error(NotImplementedError)
     end
   end
+
+  describe '#options' do
+    subject { assertion.options }
+    it { is_expected.to eq(options) }
+  end
 end

--- a/spec/create_github_release/assertions/bundle_is_up_to_date_spec.rb
+++ b/spec/create_github_release/assertions/bundle_is_up_to_date_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Assertions::BundleIsUpToDate do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -39,6 +42,7 @@ RSpec.describe CreateGithubRelease::Assertions::BundleIsUpToDate do
         let(:exitstatus) { 1 }
         it 'should fail' do
           expect { subject }.to raise_error(SystemExit)
+          expect(stderr).to match(/^ERROR: bundle update failed/)
         end
       end
     end
@@ -65,6 +69,7 @@ RSpec.describe CreateGithubRelease::Assertions::BundleIsUpToDate do
         let(:exitstatus) { 1 }
         it 'should fail' do
           expect { subject }.to raise_error(SystemExit)
+          expect(stderr).to match(/^ERROR: bundle install failed/)
         end
       end
     end

--- a/spec/create_github_release/assertions/changelog_docker_container_exists_spec.rb
+++ b/spec/create_github_release/assertions/changelog_docker_container_exists_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Assertions::ChangelogDockerContainerExists d
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -34,6 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::ChangelogDockerContainerExists d
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Failed to build the changelog-rs docker container/)
       end
     end
   end

--- a/spec/create_github_release/assertions/docker_is_running_spec.rb
+++ b/spec/create_github_release/assertions/docker_is_running_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Assertions::DockerIsRunning do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -34,6 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::DockerIsRunning do
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Docker is not installed or not running/)
       end
     end
   end

--- a/spec/create_github_release/assertions/gh_command_exists_spec.rb
+++ b/spec/create_github_release/assertions/gh_command_exists_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Assertions::GhCommandExists do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -34,6 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::GhCommandExists do
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: The gh command was not found/)
       end
     end
   end

--- a/spec/create_github_release/assertions/git_command_exists_spec.rb
+++ b/spec/create_github_release/assertions/git_command_exists_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Assertions::GitCommandExists do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -34,6 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::GitCommandExists do
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: The git command was not found/)
       end
     end
   end

--- a/spec/create_github_release/assertions/in_git_repo_spec.rb
+++ b/spec/create_github_release/assertions/in_git_repo_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Assertions::InGitRepo do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -34,6 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::InGitRepo do
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: You are not in a git repo/)
       end
     end
   end

--- a/spec/create_github_release/assertions/in_repo_root_directory_spec.rb
+++ b/spec/create_github_release/assertions/in_repo_root_directory_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe CreateGithubRelease::Assertions::InRepoRootDirectory do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -32,6 +35,7 @@ RSpec.describe CreateGithubRelease::Assertions::InRepoRootDirectory do
       let(:mocked_commands) { [MockedCommand.new('git rev-parse --show-toplevel', stdout: "/other/directory\n")] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: You are not in the repo's root directory/)
       end
     end
 
@@ -39,6 +43,7 @@ RSpec.describe CreateGithubRelease::Assertions::InRepoRootDirectory do
       let(:mocked_commands) { [MockedCommand.new('git rev-parse --show-toplevel', exitstatus: 1)] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: git rev-parse failed: 1/)
       end
     end
   end

--- a/spec/create_github_release/assertions/local_and_remote_on_same_commit_spec.rb
+++ b/spec/create_github_release/assertions/local_and_remote_on_same_commit_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe CreateGithubRelease::Assertions::LocalAndRemoteOnSameCommit do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -53,6 +56,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalAndRemoteOnSameCommit do
       let(:remote_commit) { '9535c0' }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Local and remote are not on the same commit/)
       end
     end
   end

--- a/spec/create_github_release/assertions/local_release_branch_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/local_release_branch_does_not_exist_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseBranchDoesNotExist d
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -45,6 +48,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseBranchDoesNotExist d
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: 'current-branch' already exists/)
       end
     end
 
@@ -57,6 +61,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseBranchDoesNotExist d
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not list branches/)
       end
     end
   end

--- a/spec/create_github_release/assertions/local_release_tag_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/local_release_tag_does_not_exist_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseTagDoesNotExist do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -45,6 +48,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseTagDoesNotExist do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Local tag 'v1.0.0' already exists/)
       end
     end
 
@@ -57,6 +61,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseTagDoesNotExist do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not list tags/)
       end
     end
   end

--- a/spec/create_github_release/assertions/no_staged_changes_spec.rb
+++ b/spec/create_github_release/assertions/no_staged_changes_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe CreateGithubRelease::Assertions::NoStagedChanges do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -31,6 +34,7 @@ RSpec.describe CreateGithubRelease::Assertions::NoStagedChanges do
       let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "99\n")] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: There are staged changes/)
       end
     end
 
@@ -38,6 +42,7 @@ RSpec.describe CreateGithubRelease::Assertions::NoStagedChanges do
       let(:mocked_commands) { [MockedCommand.new(git_command, exitstatus: 1)] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: git diff command failed: 1/)
       end
     end
   end

--- a/spec/create_github_release/assertions/no_uncommitted_changes_spec.rb
+++ b/spec/create_github_release/assertions/no_uncommitted_changes_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe CreateGithubRelease::Assertions::NoUncommittedChanges do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -31,6 +34,7 @@ RSpec.describe CreateGithubRelease::Assertions::NoUncommittedChanges do
       let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "99\n")] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: There are uncommitted changes/)
       end
     end
 
@@ -38,6 +42,7 @@ RSpec.describe CreateGithubRelease::Assertions::NoUncommittedChanges do
       let(:mocked_commands) { [MockedCommand.new(git_command, exitstatus: 1)] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: git status command failed: 1/)
       end
     end
   end

--- a/spec/create_github_release/assertions/on_default_branch_spec.rb
+++ b/spec/create_github_release/assertions/on_default_branch_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe CreateGithubRelease::Assertions::OnDefaultBranch do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -36,6 +39,7 @@ RSpec.describe CreateGithubRelease::Assertions::OnDefaultBranch do
       let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "other-branch\n")] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: You are not on the default branch 'default-branch'/)
       end
     end
 
@@ -43,6 +47,7 @@ RSpec.describe CreateGithubRelease::Assertions::OnDefaultBranch do
       let(:mocked_commands) { [MockedCommand.new(git_command, exitstatus: 1)] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: You are not on the default branch 'default-branch'/)
       end
     end
   end

--- a/spec/create_github_release/assertions/remote_release_branch_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/remote_release_branch_does_not_exist_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseBranchDoesNotExist 
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -49,6 +52,7 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseBranchDoesNotExist 
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: 'current-branch' already exists/)
       end
     end
 
@@ -63,6 +67,7 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseBranchDoesNotExist 
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not list branches/)
       end
     end
   end

--- a/spec/create_github_release/assertions/remote_release_tag_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/remote_release_tag_does_not_exist_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseTagDoesNotExist do
   end
 
   describe '#assert' do
-    subject { @stdout, @stderr = capture_output { assertion.assert } }
+    subject do
+      @stdout, @stderr, exception = capture_output { assertion.assert }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -45,6 +48,7 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseTagDoesNotExist do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Remote tag 'v1.0.0' already exists/)
       end
     end
 
@@ -57,6 +61,7 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseTagDoesNotExist do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not list tags/)
       end
     end
   end

--- a/spec/create_github_release/changelog_spec.rb
+++ b/spec/create_github_release/changelog_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Changelog do
+  let(:changelog) { described_class.new(existing_changelog, release) }
+  let(:release) { Object.new }
+
+  describe '#initialize' do
+    subject { changelog }
+
+    let(:existing_changelog) { 'Changelog' }
+
+    it { is_expected.to have_attributes(existing_changelog: existing_changelog, new_release: release) }
+  end
+
+  describe '#front_matter' do
+    subject { changelog.front_matter }
+
+    context 'when the changelog has both front matter and a body' do
+      let(:existing_changelog) { <<~CHANGELOG }
+        # Changelog
+
+        ## v0.1.0 (2022-10-31)
+        ...
+      CHANGELOG
+
+      let(:expected_front_matter) { <<~FRONT_MATTER.chomp }
+        # Changelog
+      FRONT_MATTER
+
+      it 'should have the expected front matter' do
+        expect(subject).to eq(expected_front_matter)
+      end
+    end
+
+    context 'when the changelog has only a body' do
+      let(:existing_changelog) { <<~CHANGELOG }
+        ## v0.1.0
+        ...
+      CHANGELOG
+
+      it 'should return an empty string' do
+        expect(subject).to eq('')
+      end
+    end
+
+    context 'when front matter starts with or ends with blank lines' do
+      let(:existing_changelog) { <<~CHANGELOG }
+
+        # Changelog
+
+        All notable changes to this project will be documented in this file.
+
+
+
+        ## v0.1.0
+        ...
+      CHANGELOG
+
+      let(:expected_front_matter) { <<~FRONT_MATTER.chomp }
+        # Changelog
+
+        All notable changes to this project will be documented in this file.
+      FRONT_MATTER
+
+      it 'should remove those blank lines' do
+        expect(subject).to eq(expected_front_matter)
+      end
+    end
+
+    context 'with a blank changelog' do
+      let(:existing_changelog) { '' }
+      it 'should return an empty string' do
+        expect(subject).to eq('')
+      end
+    end
+
+    context 'with a changelog that does not have front matter'
+  end
+
+  describe '#body' do
+    subject { changelog.body }
+
+    context 'when the changlog has both front matter and a body' do
+      let(:existing_changelog) { <<~CHANGELOG }
+        # Changelog
+
+        ## v0.1.0 (2022-10-31)
+        ...
+      CHANGELOG
+
+      let(:expected_body) { <<~BODY.chomp }
+        ## v0.1.0 (2022-10-31)
+        ...
+      BODY
+
+      it 'should have the expected body' do
+        expect(subject).to eq(expected_body)
+      end
+    end
+
+    context 'when the changelog has only a body' do
+      let(:existing_changelog) { <<~CHANGELOG }
+        ## v0.1.0 (2022-10-31)
+        ...
+      CHANGELOG
+
+      let(:expected_body) { <<~BODY.chomp }
+        ## v0.1.0 (2022-10-31)
+        ...
+      BODY
+
+      it 'should have the expected body' do
+        expect(subject).to eq(expected_body)
+      end
+    end
+
+    context 'when the changelog has only front matter' do
+      let(:existing_changelog) { <<~CHANGELOG }
+        # Changelog
+        ...
+      CHANGELOG
+
+      it 'should return an empty string' do
+        expect(subject).to eq('')
+      end
+    end
+
+    context 'when the body starts with or ends with blank lines' do
+      let(:existing_changelog) { <<~CHANGELOG }
+        # Changelog
+        ...
+
+        ## v0.1.0 (2022-10-31)
+        ...
+
+
+      CHANGELOG
+
+      let(:expected_body) { <<~BODY.chomp }
+        ## v0.1.0 (2022-10-31)
+        ...
+      BODY
+
+      it 'should remove those blank lines' do
+        expect(subject).to eq(expected_body)
+      end
+    end
+
+    context 'with a blank changelog' do
+      let(:existing_changelog) { '' }
+
+      it 'should return an empty string' do
+        expect(subject).to eq('')
+      end
+    end
+  end
+
+  describe '#to_s' do
+    let(:existing_changelog) { <<~CHANGELOG }
+      # Changelog
+
+      All notable changes to this project will be documented in this file.
+
+      The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+      and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+      ## v0.1.1 (2022-10-31)
+
+      * e718690 Release v0.1.1 (#3)
+      * a92453c Bug fix (#2)
+
+      ## v0.1.0 (2022-10-07)
+
+      * 07a1167 Release v0.1.0 (#1)
+      * 43739A3 Initial commit
+    CHANGELOG
+
+    let(:release) { CreateGithubRelease::Release.new(release_tag, release_date, release_description) }
+
+    let(:release_tag) { 'v1.0.0' }
+    let(:release_date) { Date.parse('2022-11-08') }
+    let(:release_description) { <<~RELEASE_DESCRIPTION }
+      * f5e69d6 Release v1.0.0 (#12)
+      * 8fe479b Update documentation for initial GA release (#9)
+      * 453c8bd Correctly handle file not existing (#5)
+    RELEASE_DESCRIPTION
+
+    let(:expected_to_s) { <<~CHANGELOG }
+      # Changelog
+
+      All notable changes to this project will be documented in this file.
+
+      The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+      and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+      ## v1.0.0 (2022-11-08)
+
+      * f5e69d6 Release v1.0.0 (#12)
+      * 8fe479b Update documentation for initial GA release (#9)
+      * 453c8bd Correctly handle file not existing (#5)
+
+      ## v0.1.1 (2022-10-31)
+
+      * e718690 Release v0.1.1 (#3)
+      * a92453c Bug fix (#2)
+
+      ## v0.1.0 (2022-10-07)
+
+      * 07a1167 Release v0.1.0 (#1)
+      * 43739A3 Initial commit
+    CHANGELOG
+
+    subject { changelog.to_s }
+
+    it 'should update the changelog with the new release' do
+      expect(subject).to eq(expected_to_s)
+    end
+  end
+end

--- a/spec/create_github_release/release_spec.rb
+++ b/spec/create_github_release/release_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Release do
+  let(:release) { described_class.new(tag, date, description) }
+
+  describe '#initialize' do
+    subject { release }
+    let(:tag) { 'v0.1.1' }
+    let(:date) { Date.parse('2019-01-01') }
+    let(:description) { <<~RELEASE_DESCRIPTION }
+      * f5e69d6 Release v1.0.0 (#10)
+      * 8fe479b Update document for initial GA release (#7)
+      * e718690 Release v0.1.1 (#3)
+      * a92453c Bug fix (#2)
+      * 43739A3 Initial commit
+    RELEASE_DESCRIPTION
+
+    it { is_expected.to have_attributes(tag: tag, date: date, description: description) }
+  end
+end

--- a/spec/create_github_release/release_tasks_spec.rb
+++ b/spec/create_github_release/release_tasks_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::ReleaseTasks do
+  let(:release_tasks) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  describe '#run' do
+    subject { release_tasks.run }
+
+    let(:tasks) do
+      # Assume that all classes in the Tasks module are tasks
+      tasks_module = CreateGithubRelease::Tasks
+      tasks_module.constants.select { |c| tasks_module.const_get(c).is_a? Class }
+    end
+
+    before do
+      tasks_called = []
+      @tasks_called = tasks_called
+      tasks.each do |task|
+        task_class = CreateGithubRelease::Tasks.const_get(task)
+        expect(task_class).to receive(:new).with(options) do |_options|
+          Class.new do
+            @task = task
+            @tasks_called = tasks_called
+            def run
+              self.class.instance_variable_get(:@tasks_called) << self.class.instance_variable_get(:@task)
+            end
+          end.new
+        end
+      end
+    end
+
+    it 'should instantiate and call run on all tasks' do
+      subject
+      expect(@tasks_called).to match_array(tasks)
+    end
+  end
+end

--- a/spec/create_github_release/task_base_spec.rb
+++ b/spec/create_github_release/task_base_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::TaskBase do
+  let(:task) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  describe '#run' do
+    subject { task.run }
+    it 'calling run on an instance of TaskBase should raise a NotImplementedError' do
+      expect { subject }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#options' do
+    subject { task.options }
+    it { is_expected.to eq(options) }
+  end
+end

--- a/spec/create_github_release/tasks/commit_release_spec.rb
+++ b/spec/create_github_release/tasks/commit_release_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Tasks::CommitRelease do
   end
 
   describe '#run' do
-    subject { @stdout, @stderr = capture_output { task.run } }
+    subject do
+      @stdout, @stderr, exception = capture_output { task.run }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -30,6 +33,7 @@ RSpec.describe CreateGithubRelease::Tasks::CommitRelease do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not make release commit/)
       end
     end
   end

--- a/spec/create_github_release/tasks/commit_release_spec.rb
+++ b/spec/create_github_release/tasks/commit_release_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Tasks::CommitRelease do
+  let(:task) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#run' do
+    subject { @stdout, @stderr = capture_output { task.run } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new("git commit -s -m 'Release v1.0.0'", exitstatus: git_exitstatus)
+      ]
+    end
+
+    context 'when the commit is successful' do
+      let(:git_exitstatus) { 0 }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the commit fails' do
+      let(:git_exitstatus) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/tasks/create_github_release_spec.rb
+++ b/spec/create_github_release/tasks/create_github_release_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Tasks::CreateGithubRelease do
   end
 
   describe '#run' do
-    subject { @stdout, @stderr = capture_output { task.run } }
+    subject do
+      @stdout, @stderr, exception = capture_output { task.run }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -76,6 +79,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateGithubRelease do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not generate the changelog/)
       end
     end
 
@@ -88,6 +92,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateGithubRelease do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not create a temporary file/)
       end
     end
 
@@ -102,6 +107,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateGithubRelease do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not create release/)
       end
     end
   end

--- a/spec/create_github_release/tasks/create_github_release_spec.rb
+++ b/spec/create_github_release/tasks/create_github_release_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Tasks::CreateGithubRelease do
+  let(:task) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#run' do
+    subject { @stdout, @stderr = capture_output { task.run } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    let(:changelog_file) { Object.new }
+
+    let(:expected_changelog) { <<~CHANGELOG.chomp }
+      [Full Changelog](https://github.com/user/repo/compare/v0.1.0...v1.0.0)
+
+      * 07a1167 Release v1.0.0 (#10)
+      * 8fe479b Fix worktree test when git dir includes symlinks (#7)
+    CHANGELOG
+
+    before do
+      # allow(Bump::Bump).to receive(:run).with('major', commit: false).and_return(['next.version', bump_result])
+      allow(FileUtils).to receive(:pwd).and_return('/my_worktree')
+      allow(Tempfile).to receive(:create).and_return(changelog_file)
+      allow(changelog_file).to receive(:path).and_return('/tmp/changelog')
+      allow(File).to receive(:unlink).with('/tmp/changelog')
+    end
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new(
+          "docker run --rm --volume '/my_worktree:/worktree' changelog-rs 'v0.1.0' 'v1.0.0'",
+          stdout: new_changes,
+          exitstatus: docker_exitstatus
+        ),
+        MockedCommand.new(
+          "gh release create 'v1.0.0' " \
+          "--title 'Release v1.0.0' " \
+          "--notes-file '/tmp/changelog' " \
+          "--target 'main'",
+          stdout: '',
+          exitstatus: gh_exitstatus
+        )
+      ]
+    end
+
+    let(:new_changes) { <<~NEW_CHANGES }
+      ## v1.0.0
+      [Full Changelog](https://github.com/user/repo/compare/v0.1.0...v1.0.0)
+
+      * 07a1167 Release v1.0.0 (#10)
+      * 8fe479b Fix worktree test when git dir includes symlinks (#7)
+    NEW_CHANGES
+
+    context 'when creating the Github release succeeds' do
+      let(:docker_exitstatus) { 0 }
+      before do
+        expect(changelog_file).to receive(:write).with(expected_changelog)
+        expect(changelog_file).to receive(:close)
+        expect(File).to receive(:unlink).with('/tmp/changelog')
+      end
+      let(:gh_exitstatus) { 0 }
+
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the changelog could not be generated' do
+      let(:docker_exitstatus) { 1 }
+      let(:gh_exitstatus) { 0 }
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the changelog file could not be created' do
+      let(:docker_exitstatus) { 0 }
+      before do
+        allow(Tempfile).to receive(:create).and_raise(StandardError.new('Permission denied'))
+      end
+      let(:gh_exitstatus) { 0 }
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the github release could not be created' do
+      let(:docker_exitstatus) { 0 }
+      let(:gh_exitstatus) { 1 }
+      before do
+        expect(changelog_file).to receive(:write).with(expected_changelog)
+        expect(changelog_file).to receive(:close)
+        expect(File).to receive(:unlink).with('/tmp/changelog')
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/tasks/create_release_branch_spec.rb
+++ b/spec/create_github_release/tasks/create_release_branch_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Tasks::CreateReleaseBranch do
+  let(:task) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#run' do
+    subject { @stdout, @stderr = capture_output { task.run } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new("git checkout -b 'release-v1.0.0' > /dev/null 2>&1", exitstatus: git_exitstatus)
+      ]
+    end
+
+    context 'when the release branch is created' do
+      let(:git_exitstatus) { 0 }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the release branch is not created' do
+      let(:git_exitstatus) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/tasks/create_release_branch_spec.rb
+++ b/spec/create_github_release/tasks/create_release_branch_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleaseBranch do
   end
 
   describe '#run' do
-    subject { @stdout, @stderr = capture_output { task.run } }
+    subject do
+      @stdout, @stderr, exception = capture_output { task.run }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -30,6 +33,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleaseBranch do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not create branch 'release-v1.0.0'/)
       end
     end
   end

--- a/spec/create_github_release/tasks/create_release_pull_request_spec.rb
+++ b/spec/create_github_release/tasks/create_release_pull_request_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleasePullRequest do
   end
 
   describe '#run' do
-    subject { @stdout, @stderr = capture_output { task.run } }
+    subject do
+      @stdout, @stderr, exception = capture_output { task.run }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -73,6 +76,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleasePullRequest do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not generate the changelog/)
       end
     end
 
@@ -85,6 +89,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleasePullRequest do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not create a temporary file/)
       end
     end
 
@@ -99,6 +104,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleasePullRequest do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not create release pull request/)
       end
     end
   end

--- a/spec/create_github_release/tasks/create_release_pull_request_spec.rb
+++ b/spec/create_github_release/tasks/create_release_pull_request_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Tasks::CreateReleasePullRequest do
+  let(:task) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#run' do
+    subject { @stdout, @stderr = capture_output { task.run } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    let(:pr_body_file) { Object.new }
+
+    let(:expected_pr_body) { <<~PR_BODY.chomp }
+      ## Change Log
+      [Full Changelog](https://github.com/user/repo/compare/v0.1.0...v1.0.0)
+
+      * 07a1167 Release v1.0.0 (#10)
+      * 8fe479b Fix worktree test when git dir includes symlinks (#7)
+    PR_BODY
+
+    before do
+      allow(FileUtils).to receive(:pwd).and_return('/my_worktree')
+      allow(Tempfile).to receive(:create).and_return(pr_body_file)
+      allow(pr_body_file).to receive(:path).and_return('/tmp/pr_body')
+      allow(File).to receive(:unlink).with('/tmp/pr_body')
+    end
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new(
+          "docker run --rm --volume '/my_worktree:/worktree' changelog-rs 'v0.1.0' 'v1.0.0'",
+          stdout: new_changes,
+          exitstatus: docker_exitstatus
+        ),
+        MockedCommand.new(
+          "gh pr create --title 'Release v1.0.0' --body-file '/tmp/pr_body' --base 'main'",
+          stdout: '',
+          exitstatus: gh_exitstatus
+        )
+      ]
+    end
+
+    let(:new_changes) { <<~NEW_CHANGES }
+      ## v1.0.0
+      [Full Changelog](https://github.com/user/repo/compare/v0.1.0...v1.0.0)
+
+      * 07a1167 Release v1.0.0 (#10)
+      * 8fe479b Fix worktree test when git dir includes symlinks (#7)
+    NEW_CHANGES
+
+    context 'when the release pull request is created' do
+      let(:docker_exitstatus) { 0 }
+      before do
+        expect(pr_body_file).to receive(:write).with(expected_pr_body)
+        expect(pr_body_file).to receive(:close)
+        expect(File).to receive(:unlink).with('/tmp/pr_body')
+      end
+      let(:gh_exitstatus) { 0 }
+
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the pr body file could not be generated' do
+      let(:docker_exitstatus) { 1 }
+      let(:gh_exitstatus) { 0 }
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the pr body file could not be created' do
+      let(:docker_exitstatus) { 0 }
+      before do
+        allow(Tempfile).to receive(:create).and_raise(StandardError.new('Permission denied'))
+      end
+      let(:gh_exitstatus) { 0 }
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the pull request could not be created' do
+      let(:docker_exitstatus) { 0 }
+      let(:gh_exitstatus) { 1 }
+      before do
+        expect(pr_body_file).to receive(:write).with(expected_pr_body)
+        expect(pr_body_file).to receive(:close)
+        expect(File).to receive(:unlink).with('/tmp/pr_body')
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/tasks/create_release_tag_spec.rb
+++ b/spec/create_github_release/tasks/create_release_tag_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Tasks::CreateReleaseTag do
+  let(:task) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#run' do
+    subject { @stdout, @stderr = capture_output { task.run } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new("git tag 'v1.0.0'", exitstatus: git_exitstatus)
+      ]
+    end
+
+    context 'when the release tag is created' do
+      let(:git_exitstatus) { 0 }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the release tag is not created' do
+      let(:git_exitstatus) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/tasks/create_release_tag_spec.rb
+++ b/spec/create_github_release/tasks/create_release_tag_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleaseTag do
   end
 
   describe '#run' do
-    subject { @stdout, @stderr = capture_output { task.run } }
+    subject do
+      @stdout, @stderr, exception = capture_output { task.run }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -30,6 +33,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleaseTag do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not create tag 'v1.0.0'/)
       end
     end
   end

--- a/spec/create_github_release/tasks/push_release_spec.rb
+++ b/spec/create_github_release/tasks/push_release_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Tasks::PushRelease do
   end
 
   describe '#run' do
-    subject { @stdout, @stderr = capture_output { task.run } }
+    subject do
+      @stdout, @stderr, exception = capture_output { task.run }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -33,6 +36,7 @@ RSpec.describe CreateGithubRelease::Tasks::PushRelease do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not push release commit/)
       end
     end
   end

--- a/spec/create_github_release/tasks/push_release_spec.rb
+++ b/spec/create_github_release/tasks/push_release_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Tasks::PushRelease do
+  let(:task) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#run' do
+    subject { @stdout, @stderr = capture_output { task.run } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new(
+          "git push --tags --set-upstream 'origin' 'release-v1.0.0' > /dev/null 2>&1'",
+          exitstatus: git_exitstatus
+        )
+      ]
+    end
+
+    context 'when the release is pushed' do
+      let(:git_exitstatus) { 0 }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the release is not pushed' do
+      let(:git_exitstatus) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/tasks/update_changelog_spec.rb
+++ b/spec/create_github_release/tasks/update_changelog_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Tasks::UpdateChangelog do
+  let(:task) { described_class.new(options) }
+  let(:options) do
+    CreateGithubRelease::Options.new do |o|
+      o.release_type = 'major'
+      o.current_version = '0.1.1'
+    end
+  end
+
+  before do
+    allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#run' do
+    subject { @stdout, @stderr = capture_output { task.run } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:write) do |path, content|
+        raise RuntimeError, "Unexpected file write to #{path} with #{content}"
+      end
+      allow(FileUtils).to receive(:pwd).and_return('/my_worktree')
+    end
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new(
+          'git show --format=format:%aI --quiet "v1.0.0"',
+          stdout: new_tag_date,
+          exitstatus: git_show_exitstatus
+        ),
+        MockedCommand.new(
+          "docker run --rm --volume '/my_worktree:/worktree' changelog-rs 'v0.1.1' 'v1.0.0'",
+          stdout: new_changes,
+          exitstatus: docker_exitstatus
+        ),
+        MockedCommand.new('git add CHANGELOG.md', exitstatus: git_add_exitstatus)
+      ]
+    end
+
+    let(:git_show_exitstatus) { 0 }
+    let(:docker_exitstatus) { 0 }
+    let(:git_add_exitstatus) { 0 }
+
+    let(:new_tag_date) { '2022-11-10' }
+
+    let(:existing_changelog) { <<~CHANGELOG }
+      # Changelog
+
+      ## v0.1.0 (2022-10-31)
+
+      * 123456 Change 1 (#1)
+    CHANGELOG
+
+    let(:new_changes) { <<~CHANGES.chomp }
+      ## v1.0.0
+      * 123457 Change 2 (#2)
+    CHANGES
+
+    let(:expected_new_changelog) { <<~CHANGELOG }
+      # Changelog
+
+      ## v1.0.0 (2022-11-10)
+
+      * 123457 Change 2 (#2)
+
+      ## v0.1.0 (2022-10-31)
+
+      * 123456 Change 1 (#1)
+    CHANGELOG
+
+    context 'when a changelog file and new release exists' do
+      before do
+        expect(File).to receive(:read).with('CHANGELOG.md').and_return(existing_changelog)
+        expect(File).to receive(:write).with('CHANGELOG.md', expected_new_changelog) { }
+      end
+
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when a changelog file does not exist' do
+      before do
+        expect(File).to receive(:read).with('CHANGELOG.md').and_raise(Errno::ENOENT)
+        expect(File).to receive(:write).with('CHANGELOG.md', expected_new_changelog) { }
+      end
+
+      let(:expected_new_changelog) { <<~CHANGELOG }
+        ## v1.0.0 (2022-11-10)
+
+        * 123457 Change 2 (#2)
+      CHANGELOG
+
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when the release date could not be determined' do
+      let(:git_show_exitstatus) { 1 }
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the new changes could not be determined' do
+      let(:docker_exitstatus) { 1 }
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the changelog file could not be written' do
+      before do
+        expect(File).to receive(:read).with('CHANGELOG.md').and_return(existing_changelog)
+        expect(File).to receive(:write).with('CHANGELOG.md', expected_new_changelog).and_raise(Errno::EACCES)
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when the changelog file could not be staged' do
+      before do
+        expect(File).to receive(:read).with('CHANGELOG.md').and_return(existing_changelog)
+        expect(File).to receive(:write).with('CHANGELOG.md', expected_new_changelog)
+      end
+
+      let(:git_add_exitstatus) { 1 }
+
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/tasks/update_version_spec.rb
+++ b/spec/create_github_release/tasks/update_version_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
+  let(:task) { described_class.new(options) }
+  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+
+  before do
+    allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }
+  end
+
+  describe '#run' do
+    subject { @stdout, @stderr = capture_output { task.run } }
+    let(:stdout) { @stdout }
+    let(:stderr) { @stderr }
+
+    before do
+      allow(Bump::Bump).to receive(:run).with('major', commit: false).and_return(['next.version', bump_result])
+    end
+
+    let(:mocked_commands) do
+      [
+        MockedCommand.new('git add lib/git/version.rb', exitstatus: git_exitstatus)
+      ]
+    end
+
+    context 'when Bump and git add succeed' do
+      let(:bump_result) { 0 }
+      let(:git_exitstatus) { 0 }
+      it 'should succeed' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'when Bump fails' do
+      let(:bump_result) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when git add fails' do
+      let(:bump_result) { 0 }
+      let(:git_exitstatus) { 1 }
+      it 'should fail' do
+        expect { subject }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/create_github_release/tasks/update_version_spec.rb
+++ b/spec/create_github_release/tasks/update_version_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
   end
 
   describe '#run' do
-    subject { @stdout, @stderr = capture_output { task.run } }
+    subject do
+      @stdout, @stderr, exception = capture_output { task.run }
+      raise exception if exception
+    end
     let(:stdout) { @stdout }
     let(:stderr) { @stderr }
 
@@ -35,6 +38,7 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
       let(:bump_result) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(/^ERROR: Could not bump version/)
       end
     end
 
@@ -43,6 +47,7 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
+        expect(stderr).to match(%r{^ERROR: Could not stage changes to lib/git/version\.rb})
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,27 +54,37 @@ def execute_mocked_command(mocked_commands, command)
   mocked_command.stdout
 end
 
+# rubocop:disable Metrics/MethodLength
+
 # Captures stdout and stderr output from a block of code
 #
 # @example
-#   stdout, stderr = capture_output { puts 'hello'; warn 'world' }
+#   stdout, stderr, exception = capture_output { puts 'hello'; warn 'world' }
 #   stdout # => "hello\n"
 #   stderr # => "world\n"
+#   exception # => nil
 #
 # @example Used to test an assertion
-#   subject { @stdout, @stderr = capture_output { assertion.assert } }
+#   subject { @stdout, @stderr, exception } = capture_output { assertion.assert } }
 #
 # @return [Array<String, String>] stdout and stderr output
 #
 def capture_output(&block)
   $stdout = StringIO.new
   $stderr = StringIO.new
-  block.call
-  [$stdout.string, $stderr.string]
+  exception = nil
+  begin
+    block.call
+  rescue SystemExit, StandardError => e
+    exception = e
+  end
+  [$stdout.string, $stderr.string, exception]
 ensure
   $stdout = STDOUT
   $stderr = STDERR
 end
+
+# rubocop:enable Metrics/MethodLength
 
 # Make sure to require your project AFTER SimpleCov.start
 #


### PR DESCRIPTION
This PR makes the following changes:

* Adds the tasks that actually creates a GitHub release
* Updates the specs for assertions to make sure that the proper error message is output