### PR TITLE
Add 'tmp' and 'sig' directories to rake cleanup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,3 +78,8 @@ require 'yardstick/rake/verify'
 Yardstick::Rake::Verify.new(:'yard:coverage') do |verify|
   verify.threshold = 100
 end
+
+# Additional cleanup
+
+CLEAN << 'tmp'
+CLEAN << 'sig'


### PR DESCRIPTION
This PR adds the 'tmp' and 'sig' directories to the rake CLEAN array so that `rake clean` removes these directories.