### PR TITLE
Fix error in the create-github-release script

### DIFF
--- a/exe/create-github-release
+++ b/exe/create-github-release
@@ -6,7 +6,7 @@ require 'create_github_release'
 options = CreateGithubRelease::CommandLineParser.new.parse(ARGV)
 CreateGithubRelease::ReleaseAssertions.new(options).make_assertions
 puts unless options.quiet
-CreateGithubRelease::ReleaseCreator.new(options).create_release
+CreateGithubRelease::ReleaseTasks.new(options).create_release
 
 puts <<~MESSAGE unless options.quiet
   Release '#{options.tag}' created successfully


### PR DESCRIPTION
The wrong class name was used to execute tasks.