### PR TITLE
Call the right method for creating the release

### DIFF
--- a/exe/create-github-release
+++ b/exe/create-github-release
@@ -6,7 +6,7 @@ require 'create_github_release'
 options = CreateGithubRelease::CommandLineParser.new.parse(ARGV)
 CreateGithubRelease::ReleaseAssertions.new(options).make_assertions
 puts unless options.quiet
-CreateGithubRelease::ReleaseTasks.new(options).create_release
+CreateGithubRelease::ReleaseTasks.new(options).run
 
 puts <<~MESSAGE unless options.quiet
   Release '#{options.tag}' created successfully


### PR DESCRIPTION
Call `.run` to create the release.