### PR TITLE
Do not use unneeded regexps in tests

### DIFF
--- a/spec/create_github_release/assertions/bundle_is_up_to_date_spec.rb
+++ b/spec/create_github_release/assertions/bundle_is_up_to_date_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe CreateGithubRelease::Assertions::BundleIsUpToDate do
         let(:exitstatus) { 1 }
         it 'should fail' do
           expect { subject }.to raise_error(SystemExit)
-          expect(stderr).to match(/^ERROR: bundle update failed/)
+          expect(stderr).to start_with('ERROR: bundle update failed')
         end
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe CreateGithubRelease::Assertions::BundleIsUpToDate do
         let(:exitstatus) { 1 }
         it 'should fail' do
           expect { subject }.to raise_error(SystemExit)
-          expect(stderr).to match(/^ERROR: bundle install failed/)
+          expect(stderr).to start_with('ERROR: bundle install failed')
         end
       end
     end

--- a/spec/create_github_release/assertions/changelog_docker_container_exists_spec.rb
+++ b/spec/create_github_release/assertions/changelog_docker_container_exists_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::ChangelogDockerContainerExists d
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Failed to build the changelog-rs docker container/)
+        expect(stderr).to start_with('ERROR: Failed to build the changelog-rs docker container')
       end
     end
   end

--- a/spec/create_github_release/assertions/docker_is_running_spec.rb
+++ b/spec/create_github_release/assertions/docker_is_running_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::DockerIsRunning do
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Docker is not installed or not running/)
+        expect(stderr).to start_with('ERROR: Docker is not installed or not running')
       end
     end
   end

--- a/spec/create_github_release/assertions/gh_command_exists_spec.rb
+++ b/spec/create_github_release/assertions/gh_command_exists_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::GhCommandExists do
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: The gh command was not found/)
+        expect(stderr).to start_with('ERROR: The gh command was not found')
       end
     end
   end

--- a/spec/create_github_release/assertions/git_command_exists_spec.rb
+++ b/spec/create_github_release/assertions/git_command_exists_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::GitCommandExists do
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: The git command was not found/)
+        expect(stderr).to start_with('ERROR: The git command was not found')
       end
     end
   end

--- a/spec/create_github_release/assertions/in_git_repo_spec.rb
+++ b/spec/create_github_release/assertions/in_git_repo_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CreateGithubRelease::Assertions::InGitRepo do
       let(:exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: You are not in a git repo/)
+        expect(stderr).to start_with('ERROR: You are not in a git repo')
       end
     end
   end

--- a/spec/create_github_release/assertions/in_repo_root_directory_spec.rb
+++ b/spec/create_github_release/assertions/in_repo_root_directory_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CreateGithubRelease::Assertions::InRepoRootDirectory do
       let(:mocked_commands) { [MockedCommand.new('git rev-parse --show-toplevel', stdout: "/other/directory\n")] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: You are not in the repo's root directory/)
+        expect(stderr).to start_with('ERROR: You are not in the repo\'s root directory')
       end
     end
 
@@ -43,7 +43,7 @@ RSpec.describe CreateGithubRelease::Assertions::InRepoRootDirectory do
       let(:mocked_commands) { [MockedCommand.new('git rev-parse --show-toplevel', exitstatus: 1)] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: git rev-parse failed: 1/)
+        expect(stderr).to start_with('ERROR: git rev-parse failed: 1')
       end
     end
   end

--- a/spec/create_github_release/assertions/local_and_remote_on_same_commit_spec.rb
+++ b/spec/create_github_release/assertions/local_and_remote_on_same_commit_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalAndRemoteOnSameCommit do
       let(:remote_commit) { '9535c0' }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Local and remote are not on the same commit/)
+        expect(stderr).to start_with('ERROR: Local and remote are not on the same commit')
       end
     end
   end

--- a/spec/create_github_release/assertions/local_release_branch_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/local_release_branch_does_not_exist_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseBranchDoesNotExist d
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: 'current-branch' already exists/)
+        expect(stderr).to start_with("ERROR: 'current-branch' already exists")
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseBranchDoesNotExist d
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not list branches/)
+        expect(stderr).to start_with('ERROR: Could not list branches')
       end
     end
   end

--- a/spec/create_github_release/assertions/local_release_tag_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/local_release_tag_does_not_exist_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseTagDoesNotExist do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Local tag 'v1.0.0' already exists/)
+        expect(stderr).to start_with("ERROR: Local tag 'v1.0.0' already exists")
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseTagDoesNotExist do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not list tags/)
+        expect(stderr).to start_with('ERROR: Could not list tags')
       end
     end
   end

--- a/spec/create_github_release/assertions/no_staged_changes_spec.rb
+++ b/spec/create_github_release/assertions/no_staged_changes_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CreateGithubRelease::Assertions::NoStagedChanges do
       let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "99\n")] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: There are staged changes/)
+        expect(stderr).to start_with('ERROR: There are staged changes')
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe CreateGithubRelease::Assertions::NoStagedChanges do
       let(:mocked_commands) { [MockedCommand.new(git_command, exitstatus: 1)] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: git diff command failed: 1/)
+        expect(stderr).to start_with('ERROR: git diff command failed: 1')
       end
     end
   end

--- a/spec/create_github_release/assertions/no_uncommitted_changes_spec.rb
+++ b/spec/create_github_release/assertions/no_uncommitted_changes_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CreateGithubRelease::Assertions::NoUncommittedChanges do
       let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "99\n")] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: There are uncommitted changes/)
+        expect(stderr).to start_with('ERROR: There are uncommitted changes')
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe CreateGithubRelease::Assertions::NoUncommittedChanges do
       let(:mocked_commands) { [MockedCommand.new(git_command, exitstatus: 1)] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: git status command failed: 1/)
+        expect(stderr).to start_with('ERROR: git status command failed: 1')
       end
     end
   end

--- a/spec/create_github_release/assertions/on_default_branch_spec.rb
+++ b/spec/create_github_release/assertions/on_default_branch_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CreateGithubRelease::Assertions::OnDefaultBranch do
       let(:mocked_commands) { [MockedCommand.new(git_command, stdout: "other-branch\n")] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: You are not on the default branch 'default-branch'/)
+        expect(stderr).to start_with("ERROR: You are not on the default branch 'default-branch'")
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe CreateGithubRelease::Assertions::OnDefaultBranch do
       let(:mocked_commands) { [MockedCommand.new(git_command, exitstatus: 1)] }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: You are not on the default branch 'default-branch'/)
+        expect(stderr).to start_with("ERROR: You are not on the default branch 'default-branch'")
       end
     end
   end

--- a/spec/create_github_release/assertions/remote_release_branch_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/remote_release_branch_does_not_exist_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseBranchDoesNotExist 
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: 'current-branch' already exists/)
+        expect(stderr).to start_with("ERROR: 'current-branch' already exists")
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseBranchDoesNotExist 
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not list branches/)
+        expect(stderr).to start_with('ERROR: Could not list branches')
       end
     end
   end

--- a/spec/create_github_release/assertions/remote_release_tag_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/remote_release_tag_does_not_exist_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseTagDoesNotExist do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Remote tag 'v1.0.0' already exists/)
+        expect(stderr).to start_with("ERROR: Remote tag 'v1.0.0' already exists")
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe CreateGithubRelease::Assertions::RemoteReleaseTagDoesNotExist do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not list tags/)
+        expect(stderr).to start_with('ERROR: Could not list tags')
       end
     end
   end

--- a/spec/create_github_release/tasks/commit_release_spec.rb
+++ b/spec/create_github_release/tasks/commit_release_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CreateGithubRelease::Tasks::CommitRelease do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not make release commit/)
+        expect(stderr).to start_with('ERROR: Could not make release commit')
       end
     end
   end

--- a/spec/create_github_release/tasks/create_github_release_spec.rb
+++ b/spec/create_github_release/tasks/create_github_release_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateGithubRelease do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not generate the changelog/)
+        expect(stderr).to start_with('ERROR: Could not generate the changelog')
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateGithubRelease do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not create a temporary file/)
+        expect(stderr).to start_with('ERROR: Could not create a temporary file')
       end
     end
 
@@ -107,7 +107,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateGithubRelease do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not create release/)
+        expect(stderr).to start_with('ERROR: Could not create release')
       end
     end
   end

--- a/spec/create_github_release/tasks/create_release_branch_spec.rb
+++ b/spec/create_github_release/tasks/create_release_branch_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleaseBranch do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not create branch 'release-v1.0.0'/)
+        expect(stderr).to start_with("ERROR: Could not create branch 'release-v1.0.0'")
       end
     end
   end

--- a/spec/create_github_release/tasks/create_release_pull_request_spec.rb
+++ b/spec/create_github_release/tasks/create_release_pull_request_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleasePullRequest do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not generate the changelog/)
+        expect(stderr).to start_with('ERROR: Could not generate the changelog')
       end
     end
 
@@ -89,7 +89,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleasePullRequest do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not create a temporary file/)
+        expect(stderr).to start_with('ERROR: Could not create a temporary file')
       end
     end
 
@@ -104,7 +104,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleasePullRequest do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not create release pull request/)
+        expect(stderr).to start_with('ERROR: Could not create release pull request')
       end
     end
   end

--- a/spec/create_github_release/tasks/create_release_tag_spec.rb
+++ b/spec/create_github_release/tasks/create_release_tag_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CreateGithubRelease::Tasks::CreateReleaseTag do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not create tag 'v1.0.0'/)
+        expect(stderr).to start_with("ERROR: Could not create tag 'v1.0.0'")
       end
     end
   end

--- a/spec/create_github_release/tasks/push_release_spec.rb
+++ b/spec/create_github_release/tasks/push_release_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CreateGithubRelease::Tasks::PushRelease do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not push release commit/)
+        expect(stderr).to start_with('ERROR: Could not push release commit')
       end
     end
   end

--- a/spec/create_github_release/tasks/update_changelog_spec.rb
+++ b/spec/create_github_release/tasks/update_changelog_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateChangelog do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not stage changes to CHANGELOG.md/)
+        expect(stderr).to start_with('ERROR: Could not stage changes to CHANGELOG.md')
       end
     end
 
@@ -128,7 +128,7 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateChangelog do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not generate the release notes/)
+        expect(stderr).to start_with('ERROR: Could not generate the release notes')
       end
     end
 
@@ -140,7 +140,7 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateChangelog do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not write to CHANGELOG.md: Permission denied/)
+        expect(stderr).to start_with('ERROR: Could not write to CHANGELOG.md: Permission denied')
       end
     end
 
@@ -158,7 +158,7 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateChangelog do
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not stage changes to CHANGELOG.md/)
+        expect(stderr).to start_with('ERROR: Could not stage changes to CHANGELOG.md')
       end
     end
   end

--- a/spec/create_github_release/tasks/update_version_spec.rb
+++ b/spec/create_github_release/tasks/update_version_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
       let(:bump_result) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(/^ERROR: Could not bump version/)
+        expect(stderr).to start_with('ERROR: Could not bump version')
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
       let(:git_exitstatus) { 1 }
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to match(%r{^ERROR: Could not stage changes to lib/git/version\.rb})
+        expect(stderr).to start_with('ERROR: Could not stage changes to lib/git/version.rb')
       end
     end
   end


### PR DESCRIPTION
Rather than using a regexp to test the output of the assertions and tasks, use simple string comparison to keep things less complex.

Replace this:
```Ruby
expect(stderr).to match(%r{^ERROR: Could not stage changes to lib/git/version\.rb})
```

with this:

```Ruby
expect(stderr).to start_with('ERROR: Could not stage changes to lib/git/version.rb')
```