### PR TITLE
Require date to fix error when updating the changelog

### DIFF
--- a/lib/create_github_release/tasks/update_changelog.rb
+++ b/lib/create_github_release/tasks/update_changelog.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'date'
 require 'English'
 require 'create_github_release/task_base'
 


### PR DESCRIPTION
`update_changelog.rb` uses the `Date` class but did not `require 'date'`.