### PR TITLE
Options#default_branch should not run git in specs

### DIFF
--- a/spec/create_github_release/tasks/create_github_release_spec.rb
+++ b/spec/create_github_release/tasks/create_github_release_spec.rb
@@ -2,7 +2,13 @@
 
 RSpec.describe CreateGithubRelease::Tasks::CreateGithubRelease do
   let(:task) { described_class.new(options) }
-  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+  let(:options) do
+    CreateGithubRelease::Options.new do |o|
+      o.release_type = 'major'
+      o.current_version = '0.1.0'
+      o.default_branch = 'main'
+    end
+  end
 
   before do
     allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }

--- a/spec/create_github_release/tasks/create_release_pull_request_spec.rb
+++ b/spec/create_github_release/tasks/create_release_pull_request_spec.rb
@@ -2,7 +2,13 @@
 
 RSpec.describe CreateGithubRelease::Tasks::CreateReleasePullRequest do
   let(:task) { described_class.new(options) }
-  let(:options) { CreateGithubRelease::Options.new { |o| o.release_type = 'major' } }
+  let(:options) do
+    CreateGithubRelease::Options.new do |o|
+      o.release_type = 'major'
+      o.current_version = '0.1.0'
+      o.default_branch = 'main'
+    end
+  end
 
   before do
     allow(task).to receive(:`).with(String) { |command| execute_mocked_command(mocked_commands, command) }


### PR DESCRIPTION
Set Options#default_branch in the tests of classes that use default_branch so that git is not actually run.