### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.2.0 (2022-11-15)
+
+[Full Changelog](https://github.com/main-branch/create_github_release/compare/v0.1.0...v0.2.0)
+
+* 039b152 Make it so Options#default_branch does not actually run git (#17)
+* 754224c Require date (#15)
+* 7789a28 Do not hardcode the version file path (#14)
+* 73b61bd Do not use unneeded regexps in tests (#13)
+* 6fa12e5 Create the release tag before trying to create the release branch (#12)
+* 819afd3 Call the right method for creating the release (#11)
+* 8a0fe61 Fix error in the create-github-release script (#10)
+* 6999d91 Execute the tasks from the create-github-release script (#9)
+* 819b657 Add a changelog file (#8)
+* 697fb95 Add 'tmp' and 'sig' directories to rake cleanup (#7)
+* 993e121 Add release tasks (#6)
+* a2d0b4d Add assertion to check that the git command is in the path (#5)
+* c3ed55b Refactor assertions (#4)
+* 0f3733e Add release assertions (#3)
+* a2c00ee Add the CommandLineParser class (#2)
+* 9535c0e Add the Options class (#1)
+
 ## v0.1.0 (2022-10-26)
 
 * Initial version (976b790)

--- a/lib/create_github_release/version.rb
+++ b/lib/create_github_release/version.rb
@@ -2,5 +2,5 @@
 
 module CreateGithubRelease
   # The version of this gem
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
## Change Log
[Full Changelog](https://github.com/main-branch/create_github_release/compare/v0.1.0...v0.2.0)

* 039b152 Make it so Options#default_branch does not actually run git (#17)
* 754224c Require date (#15)
* 7789a28 Do not hardcode the version file path (#14)
* 73b61bd Do not use unneeded regexps in tests (#13)
* 6fa12e5 Create the release tag before trying to create the release branch (#12)
* 819afd3 Call the right method for creating the release (#11)
* 8a0fe61 Fix error in the create-github-release script (#10)
* 6999d91 Execute the tasks from the create-github-release script (#9)
* 819b657 Add a changelog file (#8)
* 697fb95 Add 'tmp' and 'sig' directories to rake cleanup (#7)
* 993e121 Add release tasks (#6)
* a2d0b4d Add assertion to check that the git command is in the path (#5)
* c3ed55b Refactor assertions (#4)
* 0f3733e Add release assertions (#3)
* a2c00ee Add the CommandLineParser class (#2)
* 9535c0e Add the Options class (#1)