### PR TITLE
Add CodeClimate badges and test coverage reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,29 @@ jobs:
 
       - name: Run rake
         run: bundle exec rake
+
+  coverage:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    name: Report test coverage to CodeClimate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake spec
+
+      - name: Report test coverage
+        uses: paambaati/codeclimate-action@v3.2.0
+        env:
+          CC_TEST_REPORTER_ID: 89aff99f016ae5eb4bc5437c5e1b1ea6ffaacd8b20cea6b4873288a822bdb9ee
+        with:
+          coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "cSpell.words": [
+    "codeclimate",
+    "lcov",
+    "paambaati"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # The create_github_release Gem
 
+[![Gem Version](https://badge.fury.io/rb/create_github_release.svg)](https://badge.fury.io/rb/create_github_release)
+ [![Build Status](https://github.com/main-branch/create_github_release/workflows/Ruby/badge.svg?branch=main)](https://github.com/main-branch/create_github_release/actions?query=workflow%3ARuby)
+ [![Maintainability](https://api.codeclimate.com/v1/badges/b8c0af10b15a0ffeb1a1/maintainability)](https://codeclimate.com/github/main-branch/create_github_release/maintainability)
+ [![Test Coverage](https://api.codeclimate.com/v1/badges/b8c0af10b15a0ffeb1a1/test_coverage)](https://codeclimate.com/github/main-branch/create_github_release/test_coverage)
+
 Create a GitHub release for a new gem version.
 
 To create a new GitHub release for a gem, run the following from the top level

--- a/create_github_release.gemspec
+++ b/create_github_release.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rubocop', '~> 1.36'
   spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
   spec.add_development_dependency 'solargraph', '~> 0.47'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yardstick', '~> 0.9'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,9 @@ end
 # Setup simplecov
 
 require 'simplecov'
+require 'simplecov-lcov'
 
-SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter]
+SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::LcovFormatter]
 
 # Fail the rspec run if code coverage falls below the configured threshold
 #


### PR DESCRIPTION
* Report unit test code coverage to CodeClimate in the build which requires outputting coverage information in the LCOV format
* Add CodeClimate maintainability badge to README.md
* Add CodeClimate code coverage badges to README.md
* Add RubyGem badge showing the latest gem version