### PR TITLE
Normalize local release branch and local release tag assertions

### DIFF
--- a/lib/create_github_release/assertions/local_release_branch_does_not_exist.rb
+++ b/lib/create_github_release/assertions/local_release_branch_does_not_exist.rb
@@ -31,13 +31,13 @@ module CreateGithubRelease
       def assert
         print "Checking that local branch ' #{options.branch}' does not exist..."
 
-        branch_count = `git branch --list '#{options.branch}' | wc -l`.to_i
+        branches = `git branch --list "#{options.branch}"`.chomp
         error 'Could not list branches' unless $CHILD_STATUS.success?
 
-        if branch_count.zero?
+        if branches == ''
           puts 'OK'
         else
-          error "'#{options.branch}' already exists."
+          error "Local branch '#{options.branch}' already exists"
         end
       end
     end

--- a/lib/create_github_release/assertions/local_release_tag_does_not_exist.rb
+++ b/lib/create_github_release/assertions/local_release_tag_does_not_exist.rb
@@ -34,7 +34,7 @@ module CreateGithubRelease
         tags = `git tag --list "#{options.tag}"`.chomp
         error 'Could not list tags' unless $CHILD_STATUS.success?
 
-        if tags.split.empty?
+        if tags == ''
           puts 'OK'
         else
           error "Local tag '#{options.tag}' already exists"

--- a/spec/create_github_release/assertions/local_release_branch_does_not_exist_spec.rb
+++ b/spec/create_github_release/assertions/local_release_branch_does_not_exist_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseBranchDoesNotExist d
     context 'when the local release branch does not exist' do
       let(:mocked_commands) do
         [
-          MockedCommand.new('git branch --list "current-branch" | wc -l', stdout: "0\n")
+          MockedCommand.new('git branch --list "current-branch"', stdout: "\n")
         ]
       end
 
@@ -42,13 +42,13 @@ RSpec.describe CreateGithubRelease::Assertions::LocalReleaseBranchDoesNotExist d
     context 'when the local release branch exists' do
       let(:mocked_commands) do
         [
-          MockedCommand.new('git branch --list "current-branch" | wc -l', stdout: "1\n")
+          MockedCommand.new('git branch --list "current-branch"', stdout: "  current-branch\n")
         ]
       end
 
       it 'should fail' do
         expect { subject }.to raise_error(SystemExit)
-        expect(stderr).to start_with("ERROR: 'current-branch' already exists")
+        expect(stderr).to start_with("ERROR: Local branch 'current-branch' already exists")
       end
     end
 


### PR DESCRIPTION
Make the assertions for LocalReleaseBranchDoesNotExist and LocalREleaseTagDoesNotExist be accomplished using the same way.