### PR TITLE
Create release tag after committing release changes

### DIFF
--- a/lib/create_github_release/release_tasks.rb
+++ b/lib/create_github_release/release_tasks.rb
@@ -46,11 +46,11 @@ module CreateGithubRelease
     # @return [Array<Class>] The tasks that will be run to create a new Github release
     #
     TASKS = [
-      CreateGithubRelease::Tasks::CreateReleaseTag,
       CreateGithubRelease::Tasks::CreateReleaseBranch,
       CreateGithubRelease::Tasks::UpdateVersion,
       CreateGithubRelease::Tasks::UpdateChangelog,
       CreateGithubRelease::Tasks::CommitRelease,
+      CreateGithubRelease::Tasks::CreateReleaseTag,
       CreateGithubRelease::Tasks::PushRelease,
       CreateGithubRelease::Tasks::CreateGithubRelease,
       CreateGithubRelease::Tasks::CreateReleasePullRequest


### PR DESCRIPTION
The release tag should include the commit that bumps the version and updates the changelog.

Signed-off-by: James Couball <jcouball@yahoo.com>