### PR TITLE
If no changes, say "No changes" in the release description

### DIFF
--- a/lib/create_github_release/project.rb
+++ b/lib/create_github_release/project.rb
@@ -578,6 +578,8 @@ module CreateGithubRelease
 
         [Full Changelog](#{release_log_url})
 
+        Changes since #{last_release_tag}:
+
         #{list_of_changes}
       DESCRIPTION
     end
@@ -762,6 +764,8 @@ module CreateGithubRelease
     # @return [String] The list of changes in the release as a string
     # @api private
     def list_of_changes
+      return '* No changes' if changes.empty?
+
       changes.map do |change|
         "* #{change.sha} #{change.subject}"
       end.join("\n")

--- a/spec/create_github_release/project_spec.rb
+++ b/spec/create_github_release/project_spec.rb
@@ -506,8 +506,34 @@ RSpec.describe CreateGithubRelease::Project do
 
           [Full Changelog](https://github.com/username/repo/compare/v0.1.0..v1.0.0)
 
+          Changes since v0.1.0:
+
           * e718690 Release v1.0.0 (#3)
           * ab598f3 Fix Rubocop offenses (#2)
+        NEXT_RELEASE_DESCRIPTION
+      end
+
+      it { is_expected.to eq(expected_next_release_description) }
+    end
+
+    context 'when there are no changes' do
+      before do
+        project.remote_url = URI.parse('https://github.com/username/repo')
+        project.last_release_tag = 'v0.1.0'
+        project.next_release_tag = 'v1.0.0'
+        project.next_release_date = Date.new(2022, 11, 7)
+        project.changes = []
+      end
+
+      let(:expected_next_release_description) do
+        <<~NEXT_RELEASE_DESCRIPTION
+          ## v1.0.0 (2022-11-07)
+
+          [Full Changelog](https://github.com/username/repo/compare/v0.1.0..v1.0.0)
+
+          Changes since v0.1.0:
+
+          * No changes
         NEXT_RELEASE_DESCRIPTION
       end
 


### PR DESCRIPTION
When listing the changes in a release, prefix the list of changes with:

```text
Changes since #{last_release_tag}:
```

If there are no changes, include the following in the release description:

```text
* No changes
```