### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.3.0 (2023-01-29)
+
+[Full Changelog](https://github.com/main-branch/create_github_release/compare/v0.2.1..v0.3.0)
+
+Changes since v0.2.1:
+
+* 92ce55a Report "no changes" in the release description (#30)
+* 1b3505b Assert that gh has been authenticated (#29)
+* c7bd12d Complete redesign of this gem (#28)
+* d75e1e9 Create release tag after committing release changes (#27)
+* 24bdd02 Release v0.2.1
+
 ## v0.2.1 (2022-11-16)
 
 [Full Changelog](https://github.com/main-branch/create_github_release/compare/v0.2.0...v0.2.1)

--- a/lib/create_github_release/version.rb
+++ b/lib/create_github_release/version.rb
@@ -2,5 +2,5 @@
 
 module CreateGithubRelease
   # The version of this gem
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
# Release PR

## v0.3.0 (2023-01-29)

[Full Changelog](https://github.com/main-branch/create_github_release/compare/v0.2.1..v0.3.0)

Changes since v0.2.1:

* 92ce55a Report "no changes" in the release description (#30)
* 1b3505b Assert that gh has been authenticated (#29)
* c7bd12d Complete redesign of this gem (#28)
* d75e1e9 Create release tag after committing release changes (#27)
* 24bdd02 Release v0.2.1
