### PR TITLE
Replace 'bump' with 'semverify'

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Options:
         --release-branch=BRANCH_NAME Override the release branch to create
         --remote=REMOTE_NAME         Use this remote name instead of 'origin'
         --last-release-version=VERSION
-                                     Use this version instead `bump current`
+                                     Use this version instead `semverify current`
         --next-release-version=VERSION
-                                     Use this version instead `bump RELEASE_TYPE`
+                                     Use this version instead `semverify RELEASE_TYPE`
         --changelog-path=PATH        Use this file instead of CHANGELOG.md
     -q, --[no-]quiet                 Do not show output
     -v, --[no-]verbose               Show extra output
@@ -76,10 +76,10 @@ If this is to be the first release of this gem follow these instructions.
 For this use case, let's assume the following:
 
 * the default branch is `main` (this is the HEAD branch returned by `git remote show origin`)
-* the current version of the gem is `0.1.0` (as returned by `bump current`)
+* the current version of the gem is `0.1.0` (as returned by `semverify current`)
 
 If a different first version number is desired, update the version number in the
-source code making sure that `bump current` returns the desired version number.
+source code making sure that `semverify current` returns the desired version number.
 Then commit the change to the default branch on the remote before running this
 script.
 
@@ -117,7 +117,7 @@ create-github-release first
 
 The `create-github-release` script will do the following:
 
-* Determine the next-release version (`v0.1.0`) using `bump current`
+* Determine the next-release version (`v0.1.0`) using `semverify current`
 * Update the project's changelog file `CHANGELOG.md`
 * Create a release branch `release-v0.1.0`
 * Commit the changes to the changelog and create a release tag (`v0.1.0`) pointing
@@ -134,7 +134,7 @@ In order to start using `create-github-release` after you have used some other
 method for managing the gem version and creating releases, you need to ensure the
 following prerequisites are met:
 
-1. that `bump current` is the version of the last release (let's use `1.3.1` as an
+1. that `semverify current` is the version of the last release (let's use `1.3.1` as an
    example).
 2. that there is a corresponding release tag that points to the last commit on the
    default branch of the previous release. If the last version was `1.3.1`, then
@@ -159,7 +159,7 @@ For this use case, let's assume the following:
 
 * you want to create a `major` release
 * the default branch is `main` (this is the HEAD branch returned by `git remote show origin`)
-* the current version of the gem is `0.1.0` (as returned by `bump current`)
+* the current version of the gem is `0.1.0` (as returned by `semverify current`)
 
 The following prerequisites must be met:
 
@@ -182,9 +182,9 @@ create-github-release major
 
 The `create-github-release` script will do the following:
 
-* Determine the last-release version using `bump current`
-* Determine the next-release version using `bump show-next RELEASE_TYPE`
-* Bump the project's version using `bump RELEASE_TYPE`
+* Determine the last-release version using `semverify current`
+* Determine the next-release version using `semverify RELEASE_TYPE --dry-run`
+* Increment the project's version using `semverify RELEASE_TYPE`
 * Update the project's changelog file `CHANGELOG.md`
 * Create a release branch `release-v1.0.0`
 * Commit the changes to the version and changelog AND create a release tag (`v1.0.0`) pointing

--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,6 @@ end
 CLEAN << 'pkg'
 CLOBBER << 'Gemfile.lock'
 
-# Bump
-
-require 'bump/tasks'
-
 # RSpec
 
 require 'rspec/core/rake_task'

--- a/create_github_release.gemspec
+++ b/create_github_release.gemspec
@@ -34,14 +34,14 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'bump', '~> 0.10'
+  spec.add_runtime_dependency 'semverify', '~> 0.3'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'redcarpet', '~> 3.6'
-  spec.add_development_dependency 'rspec', '~> 3.12'
-  spec.add_development_dependency 'rubocop', '~> 1.50'
-  spec.add_development_dependency 'simplecov', '~> 0.22'
+  spec.add_development_dependency 'redcarpet', '~> 3.5'
+  spec.add_development_dependency 'rspec', '~> 3.10'
+  spec.add_development_dependency 'rubocop', '~> 1.36'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
   spec.add_development_dependency 'solargraph', '~> 0.49'
   spec.add_development_dependency 'timecop', '~> 0.9'

--- a/lib/create_github_release/command_line_parser.rb
+++ b/lib/create_github_release/command_line_parser.rb
@@ -199,7 +199,7 @@ module CreateGithubRelease
     # @return [void]
     # @api private
     def define_last_release_version_option
-      option_parser.on('--last-release-version=VERSION', 'Use this version instead `bump current`') do |version|
+      option_parser.on('--last-release-version=VERSION', 'Use this version instead `semverify current`') do |version|
         options.last_release_version = version
       end
     end
@@ -208,7 +208,10 @@ module CreateGithubRelease
     # @return [void]
     # @api private
     def define_next_release_version_option
-      option_parser.on('--next-release-version=VERSION', 'Use this version instead `bump RELEASE_TYPE`') do |version|
+      option_parser.on(
+        '--next-release-version=VERSION',
+        'Use this version instead `semverify next-RELEASE_TYPE`'
+      ) do |version|
         options.next_release_version = version
       end
     end

--- a/lib/create_github_release/project.rb
+++ b/lib/create_github_release/project.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'bump'
+require 'semverify'
 require 'uri'
 
 module CreateGithubRelease
@@ -193,7 +193,7 @@ module CreateGithubRelease
     #
     # The version of the next release
     #
-    # @example By default, `next_release_version` is based on the value returned by `bump show-next <release_type>`
+    # @example By default, `next_release_version` is based on the value returned by `semverify <release_type> --dry-run`
     #   options = CreateGithubRelease::CommandLineOptions.new(release_type: 'major')
     #   project = CreateGithubRelease::Project.new(options)
     #   project.next_release_version #=> '1.0.0'
@@ -206,12 +206,12 @@ module CreateGithubRelease
     #
     # @return [String]
     #
-    # @raise [RuntimeError] if the bump command fails
+    # @raise [RuntimeError] if the semverify command fails
     #
     # @api public
     #
     def next_release_version
-      @next_release_version ||= options.next_release_version || bump_show_next_version
+      @next_release_version ||= options.next_release_version || next_version
     end
 
     # @!attribute [rw] last_release_tag
@@ -244,7 +244,7 @@ module CreateGithubRelease
     #
     # The version of the last release
     #
-    # @example By default, `last_release_version` is based on the value returned by `bump current`
+    # @example By default, `last_release_version` is based on the value returned by `semverify current`
     #   options = CreateGithubRelease::CommandLineOptions.new(release_type: 'major')
     #   project = CreateGithubRelease::Project.new(options)
     #   project.last_release_version #=> '0.0.1'
@@ -257,12 +257,12 @@ module CreateGithubRelease
     #
     # @return [String]
     #
-    # @raise [RuntimeError] if the bump command fails
+    # @raise [RuntimeError] if the semverify command fails
     #
     # @api public
     #
     def last_release_version
-      @last_release_version ||= options.last_release_version || bump_current_version
+      @last_release_version ||= options.last_release_version || current_version
     end
 
     # @!attribute [rw] release_branch
@@ -283,7 +283,7 @@ module CreateGithubRelease
     #
     # @return [String]
     #
-    # @raise [RuntimeError] if the bump command fails
+    # @raise [RuntimeError] if the semverify command fails
     #
     # @api public
     #
@@ -311,7 +311,7 @@ module CreateGithubRelease
     #
     # @return [URI]
     #
-    # @raise [RuntimeError] if the bump command fails
+    # @raise [RuntimeError] if the semverify command fails
     #
     # @api public
     #
@@ -327,7 +327,7 @@ module CreateGithubRelease
     #
     # The type of the release being created (e.g. 'major', 'minor', 'patch')
     #
-    # @note this must be one of the values accepted by the `bump` command
+    # @note this must be one of the values accepted by the `semverify` command
     #
     # @example By default, this value comes from the options object
     #   options = CreateGithubRelease::CommandLineOptions.new(release_type: 'major')
@@ -812,22 +812,22 @@ module CreateGithubRelease
 
     private
 
-    # The current version of the project as determined by bump
+    # The current version of the project as determined by semverify
     # @return [String] The current version of the project
     # @api private
-    def bump_current_version
-      output = `bump current`
-      raise 'Could not determine current version using bump' unless $CHILD_STATUS.success?
+    def current_version
+      output = `semverify current`
+      raise 'Could not determine current version using semverify' unless $CHILD_STATUS.success?
 
       output.lines.last.chomp
     end
 
-    # The next version of the project as determined by bump and release_type
+    # The next version of the project as determined by semverify and release_type
     # @return [String] The next version of the project
     # @api private
-    def bump_show_next_version
-      output = `bump show-next #{release_type}`
-      raise 'Could not determine next version using bump' unless $CHILD_STATUS.success?
+    def next_version
+      output = `semverify next-#{release_type} --dry-run`
+      raise 'Could not determine next version using semverify' unless $CHILD_STATUS.success?
 
       output.lines.last.chomp
     end
@@ -836,7 +836,7 @@ module CreateGithubRelease
     # @return [Void]
     # @api private
     def setup_first_release
-      self.next_release_version = @next_release_version || bump_current_version
+      self.next_release_version = @next_release_version || current_version
       self.last_release_version = ''
       self.last_release_tag = ''
     end

--- a/lib/create_github_release/tasks/update_version.rb
+++ b/lib/create_github_release/tasks/update_version.rb
@@ -5,12 +5,12 @@ require 'create_github_release/task_base'
 
 module CreateGithubRelease
   module Tasks
-    # Update the gem version using Bump
+    # Update the gem version using semverify
     #
     # @api public
     #
     class UpdateVersion < TaskBase
-      # Update the gem version using Bump
+      # Update the gem version using semverify
       #
       # @example
       #   require 'create_github_release'
@@ -33,35 +33,34 @@ module CreateGithubRelease
         return if project.first_release?
 
         print 'Updating version...'
-        bump_version
+        increment_version
         stage_version_file
       end
 
       private
 
-      # Update the version using bump
+      # Increment the version using semverify
       # @return [void]
       # @api private
-      def bump_version
-        `bump #{project.release_type} --no-commit`
-        error 'Could not bump version' unless $CHILD_STATUS.success?
+      def increment_version
+        `semverify next-#{project.release_type}`
+        error 'Could not increment version' unless $CHILD_STATUS.success?
       end
 
-      # Return the path the the version file using bump
+      # Return the path the the version file using semverify
       # @return [String]
       # @api private
-      def bump_version_file
-        output = `bump file`
-        error 'Bump could determine the version file' unless $CHILD_STATUS.success?
+      def version_file
+        output = `semverify file`
+        error 'Semverify could determine the version file' unless $CHILD_STATUS.success?
 
         output.lines.last.chomp
       end
 
-      # Identify the version file using bump and stage the change to it
+      # Identify the version file using semverify and stage the change to it
       # @return [void]
       # @api private
       def stage_version_file
-        version_file = bump_version_file
         `git add "#{version_file}"`
         if $CHILD_STATUS.success?
           puts 'OK'

--- a/spec/create_github_release/project_spec.rb
+++ b/spec/create_github_release/project_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe CreateGithubRelease::Project do
       end
     end
 
-    context "when release_type is 'first' and 'bump current' returns 0.0.1" do
+    context "when release_type is 'first' and 'semverify current' returns 0.0.1" do
       let(:release_type) { 'first' }
 
       subject { project }
 
-      let(:mocked_commands) { [MockedCommand.new('bump current', stdout: "0.0.1\n")] }
+      let(:mocked_commands) { [MockedCommand.new('semverify current', stdout: "0.0.1\n")] }
 
       it do
         is_expected.to(
@@ -200,28 +200,28 @@ RSpec.describe CreateGithubRelease::Project do
     context 'when not otherwise specified' do
       context 'when this is the first release' do
         let(:release_type) { 'first' }
-        let(:mocked_commands) { [MockedCommand.new('bump current', stdout: "1.0.0\n")] }
-        it "should determine the version using 'bump current'" do
+        let(:mocked_commands) { [MockedCommand.new('semverify current', stdout: "1.0.0\n")] }
+        it "should determine the version using 'semverify current'" do
           expect(subject).to eq('1.0.0')
         end
       end
 
-      context 'when the bump command succeeds' do
-        let(:mocked_commands) { [MockedCommand.new('bump show-next major', stdout: "1.0.0\n")] }
+      context 'when the semverify command succeeds' do
+        let(:mocked_commands) { [MockedCommand.new('semverify next-major --dry-run', stdout: "1.0.0\n")] }
         it { is_expected.to eq('1.0.0') }
       end
 
-      context 'when the bump command succeeds with extra output' do
+      context 'when the semverify command succeeds with extra output' do
         let(:mocked_commands) do
           [
-            MockedCommand.new('bump show-next major', stdout: "Resolving dependencies...\n1.0.0\n")
+            MockedCommand.new('semverify next-major --dry-run', stdout: "Resolving dependencies...\n1.0.0\n")
           ]
         end
         it { is_expected.to eq('1.0.0') }
       end
 
-      context 'when the bump command fails' do
-        let(:mocked_commands) { [MockedCommand.new('bump show-next major', exitstatus: 1)] }
+      context 'when the semverify command fails' do
+        let(:mocked_commands) { [MockedCommand.new('semverify next-major --dry-run', exitstatus: 1)] }
         it 'should raise a RuntimeError' do
           expect { subject }.to raise_error(RuntimeError)
         end
@@ -280,28 +280,28 @@ RSpec.describe CreateGithubRelease::Project do
 
       context 'when this is the first release' do
         let(:release_type) { 'first' }
-        let(:mocked_commands) { [MockedCommand.new('bump current', stdout: '0.0.1')] }
+        let(:mocked_commands) { [MockedCommand.new('semverify current', stdout: '0.0.1')] }
         it 'should return an empty string' do
           expect(subject).to eq('')
         end
       end
 
-      context 'when the bump command succeeds' do
-        let(:mocked_commands) { [MockedCommand.new('bump current', stdout: "0.0.1\n")] }
+      context 'when the semverify command succeeds' do
+        let(:mocked_commands) { [MockedCommand.new('semverify current', stdout: "0.0.1\n")] }
         it { is_expected.to eq('0.0.1') }
       end
 
-      context 'when the bump command succeeds with extra output' do
+      context 'when the semverify command succeeds with extra output' do
         let(:mocked_commands) do
           [
-            MockedCommand.new('bump current', stdout: "Resolving dependencies...\n0.0.1\n")
+            MockedCommand.new('semverify current', stdout: "Resolving dependencies...\n0.0.1\n")
           ]
         end
         it { is_expected.to eq('0.0.1') }
       end
 
-      context 'when the bump command fails' do
-        let(:mocked_commands) { [MockedCommand.new('bump current', exitstatus: '1')] }
+      context 'when the semverify command fails' do
+        let(:mocked_commands) { [MockedCommand.new('semverify current', exitstatus: '1')] }
         it 'should raise a RuntimeError' do
           expect { subject }.to raise_error(RuntimeError)
         end
@@ -881,9 +881,9 @@ RSpec.describe CreateGithubRelease::Project do
     let(:mocked_commands) do
       [
         MockedCommand.new("git remote show 'origin'", stdout: "  HEAD branch: main\n"),
-        MockedCommand.new('bump show-next major', stdout: "1.0.0\n"),
+        MockedCommand.new('semverify next-major --dry-run', stdout: "1.0.0\n"),
         MockedCommand.new('git show --format=format:%aI --quiet "v1.0.0"', stdout: "2023-02-01 00:00:00 -0800\n"),
-        MockedCommand.new('bump current', stdout: "0.1.0\n"),
+        MockedCommand.new('semverify current', stdout: "0.1.0\n"),
         MockedCommand.new("git remote get-url 'origin'", stdout: "https://github.com/org/repo.git\n"),
         MockedCommand.new('git tag --list "v1.0.0"', stdout: "v1.0.0\n")
       ]

--- a/spec/create_github_release/tasks/update_version_spec.rb
+++ b/spec/create_github_release/tasks/update_version_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
 
     context 'when this is the first release' do
       let(:release_type) { 'first' }
-      it 'should not bump the version' do
-        expect(task).not_to receive(:bump_version)
+      it 'should not increment the version' do
+        expect(task).not_to receive(:increment_version)
         subject
       end
     end
@@ -32,35 +32,35 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
     context 'when this is NOT the first release' do
       let(:mocked_commands) do
         [
-          MockedCommand.new('bump major --no-commit', exitstatus: bump_exitstatus),
-          MockedCommand.new('bump file', stdout: "#{version_file}\n", exitstatus: bump_file_exitstatus),
+          MockedCommand.new('semverify next-major', exitstatus: semverify_exitstatus),
+          MockedCommand.new('semverify file', stdout: "#{version_file}\n", exitstatus: semverify_file_exitstatus),
           MockedCommand.new("git add \"#{version_file}\"", exitstatus: git_exitstatus)
         ]
       end
 
-      let(:bump_exitstatus) { 0 }
-      let(:bump_file_exitstatus) { 0 }
+      let(:semverify_exitstatus) { 0 }
+      let(:semverify_file_exitstatus) { 0 }
       let(:git_exitstatus) { 0 }
 
-      context 'when bump and git add succeed' do
+      context 'when semverify and git add succeed' do
         it 'should succeed' do
           expect { subject }.not_to raise_error
         end
       end
 
-      context 'when bump fails to increment the version' do
-        let(:bump_exitstatus) { 1 }
+      context 'when semverify fails to increment the version' do
+        let(:semverify_exitstatus) { 1 }
         it 'should fail' do
           expect { subject }.to raise_error(SystemExit)
-          expect(stderr).to start_with('ERROR: Could not bump version')
+          expect(stderr).to start_with('ERROR: Could not increment version')
         end
       end
 
-      context 'when bump file fails' do
-        let(:bump_file_exitstatus) { 1 }
+      context 'when `semverify file` fails' do
+        let(:semverify_file_exitstatus) { 1 }
         it 'should fail' do
           expect { subject }.to raise_error(SystemExit)
-          expect(stderr).to start_with('ERROR: Bump could determine the version file')
+          expect(stderr).to start_with('ERROR: Semverify could determine the version file')
         end
       end
 


### PR DESCRIPTION
Replace 'bump' with 'semverify' because semverify supports creating and incrementing pre-release versions.

This PR replaces bump. Adding support for creating pre-releases will be added in a future PR.