### PR TITLE
Drop support for Ruby 2.7 and require at least Ruby 3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', 'head']
+        ruby: ['3.0', '3.1', '3.2', 'head']
 
     name: Build on Ruby ${{ matrix.ruby }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   SuggestExtensions: false
   # RuboCop enforces rules depending on the oldest version of Ruby which
   # your project supports:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # The default max line length is 80 characters
 Layout/LineLength:

--- a/create_github_release.gemspec
+++ b/create_github_release.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.homepage = 'https://github.com/main-branch/create_github_release'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.0.0'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
@@ -34,15 +34,16 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bump', '~> 0.10'
+  spec.add_runtime_dependency 'bump', '~> 0.10'
+
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'redcarpet', '~> 3.5'
-  spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'rubocop', '~> 1.36'
-  spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'redcarpet', '~> 3.6'
+  spec.add_development_dependency 'rspec', '~> 3.12'
+  spec.add_development_dependency 'rubocop', '~> 1.50'
+  spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
-  spec.add_development_dependency 'solargraph', '~> 0.47'
+  spec.add_development_dependency 'solargraph', '~> 0.49'
   spec.add_development_dependency 'timecop', '~> 0.9'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yardstick', '~> 0.9'

--- a/lib/create_github_release/command_line_options.rb
+++ b/lib/create_github_release/command_line_options.rb
@@ -13,7 +13,7 @@ module CreateGithubRelease
   # Regex pattern for a [valid git reference](https://git-scm.com/docs/git-check-ref-format)
   # @return [Regexp]
   # @api private
-  VALID_REF_PATTERN = /^(?:(?:[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)|(?:[a-zA-Z0-9-]+))$/.freeze
+  VALID_REF_PATTERN = /^(?:(?:[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)|(?:[a-zA-Z0-9-]+))$/
 
   # rubocop:disable Metrics/ClassLength
 


### PR DESCRIPTION
Now that Ruby 2.7 is EOL and no longer maintained, set the minimum version to 3.0. 