### PR TITLE
Debugging support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.ruby == 'head' }}
     strategy:
+      fail-fast: false
       matrix:
         ruby: ['3.0', '3.1', '3.2', 'head']
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Test
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "rdbg",
+      "name": "Debug current file with rdbg",
+      "request": "launch",
+      "script": "${file}",
+      "args": [],
+      "askParameters": false
+    },
+    {
+      "type": "rdbg",
+      "name": "Attach with rdbg",
+      "request": "attach"
+    }
+  ]
+}

--- a/create_github_release.gemspec
+++ b/create_github_release.gemspec
@@ -37,10 +37,12 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'semverify', '~> 0.3'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
+  spec.add_development_dependency 'debug', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'rspec', '~> 3.10'
   spec.add_development_dependency 'rubocop', '~> 1.36'
+  spec.add_development_dependency 'ruby-debug-ide', '~> 0.7'
   spec.add_development_dependency 'simplecov', '~> 0.21'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
   spec.add_development_dependency 'solargraph', '~> 0.49'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'debug'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
This PR makes the following changes:
1. Add the `debug` gem as a development dependency to support running the ruby debugger.
2. Add `require 'debug'` to spec_helper.rb to enable use of `binding.break` or `debugger` from the source code without having to do the require.
3. Add the `ruby-debug-ide` gem as a development dependency to support debugging from VS Code.
4. Add `.vscode/launch.json` to add simple debug configurations. In the Run and Debug panel (accessed with Shift-Cmd-D), these options will appear in the Start Debugging drop down at the top of the panel.