### PR TITLE
Tell rubocop that development dependencies go in the gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ Metrics/BlockLength:
   Exclude:
     - "spec/**/*_spec.rb"
     - "*.gemspec"
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec


### PR DESCRIPTION
The new cop, Gemspec/DevelopmentDependencies, ensure that development dependencies are consistently put in either the Gemfile or in the gemspec. This project uses the gemspec.

This change configures Rubocop so that all development dependencies should go in the gemspec and NOT in the Gemfile.