### PR TITLE
Add instruction for publishing the resulting gem

### DIFF
--- a/exe/create-github-release
+++ b/exe/create-github-release
@@ -23,4 +23,8 @@ puts <<~MESSAGE unless project.quiet
   git checkout #{project.default_branch}
   git merge --ff-only #{project.release_branch}
   git push
+
+  Wait for the CI build to pass and then release the gem with the following command:
+
+  rake release:rubygem_push
 MESSAGE


### PR DESCRIPTION
Add instruction to publish the gem to RubyGems.org using the command `rake release:rubygem_push`.

This will ensure that rake does not create a release tag.