### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.2.0 (2024-01-07)
+
+[Full Changelog](https://github.com/main-branch/create_github_release/compare/v1.1.0..v1.2.0)
+
+Changes since v1.1.0:
+
+* 80da449 Add support for pre-release versions (#43)
+
 ## v1.1.0 (2023-10-15)
 
 [Full Changelog](https://github.com/main-branch/create_github_release/compare/v1.0.0..v1.1.0)

--- a/lib/create_github_release/version.rb
+++ b/lib/create_github_release/version.rb
@@ -2,5 +2,5 @@
 
 module CreateGithubRelease
   # The version of this gem
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
# Release PR

## v1.2.0 (2024-01-07)

[Full Changelog](https://github.com/main-branch/create_github_release/compare/v1.1.0..v1.2.0)

Changes since v1.1.0:

* 80da449 Add support for pre-release versions (#43)
