### PR TITLE
Correctly use semverify to increment pre-release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ git push "${REMOTE}" --delete "${RELEASE_TAG}"
 
 # Delete the local branch and tag
 git branch -D "${RELEASE_BRANCH}"
-git tag -D "${RELEASE_TAG}"
+git tag -d "${RELEASE_TAG}"
 ```
 
 ### How is the changelog updated?

--- a/lib/create_github_release/tasks/update_version.rb
+++ b/lib/create_github_release/tasks/update_version.rb
@@ -43,7 +43,10 @@ module CreateGithubRelease
       # @return [void]
       # @api private
       def increment_version
-        `semverify next-#{project.release_type}`
+        command = "semverify next-#{project.release_type}"
+        command += ' --pre' if project.pre
+        command += " --pre-type=#{project.pre_type}" if project.pre_type
+        `#{command}`
         error 'Could not increment version' unless $CHILD_STATUS.success?
       end
 


### PR DESCRIPTION
The --pre and --pre-type flags are not being passed to semverify when bumping the version.