### PR TITLE
Add option to create and revert scripts to show version

### DIFF
--- a/exe/revert-github-release
+++ b/exe/revert-github-release
@@ -74,7 +74,10 @@ class Parser
     COMMAND
   end
 
-  DESCRIPTION = <<~DESCRIPTION
+  BANNER = <<~BANNER.freeze
+    Usage:
+    #{File.basename($PROGRAM_NAME)} [--help | --version]
+
     This script reverts the effect of running the create-github-release script.
     It must be run in the root directory of the work tree with the release
     branch checked out (which is the state create-github-release leaves you in).
@@ -84,20 +87,17 @@ class Parser
     This script removes the release branch and release tag both in the local
     repository and on the remote. Deleting the branch on GitHub will close the
     GitHub PR automatically.
-  DESCRIPTION
+
+    Options:
+  BANNER
 
   # Define the options for OptionParser
   # @return [void]
   # @api private
   def define_options
-    option_parser.banner = "Usage: #{command_template}"
-    option_parser.separator ''
-    option_parser.separator DESCRIPTION
-    option_parser.separator ''
-    option_parser.separator 'Options:'
-
+    option_parser.banner = BANNER
     %i[
-      define_help_option
+      define_help_option define_version_option
     ].each { |m| send(m) }
   end
 
@@ -107,6 +107,16 @@ class Parser
   def define_help_option
     option_parser.on_tail('-h', '--help', 'Show this message') do
       puts option_parser
+      exit 0
+    end
+  end
+
+  # Define the version option
+  # @return [void]
+  # @api private
+  def define_version_option
+    option_parser.on_tail('-v', '--version', 'Output the version of this script') do
+      puts CreateGithubRelease::VERSION
       exit 0
     end
   end

--- a/lib/create_github_release/command_line/parser.rb
+++ b/lib/create_github_release/command_line/parser.rb
@@ -118,28 +118,27 @@ module CreateGithubRelease
         exit 1
       end
 
-      # The command line template as a string
-      # @return [String]
-      # @api private
-      def command_template
-        <<~COMMAND
-          #{File.basename($PROGRAM_NAME)} --help | RELEASE_TYPE [options]
-        COMMAND
-      end
+      # The banner for the option parser
+      BANNER = <<~BANNER.freeze
+        Usage:
+        #{File.basename($PROGRAM_NAME)} --help | RELEASE_TYPE [options]
+
+        Version #{CreateGithubRelease::VERSION}
+
+        RELEASE_TYPE must be 'major', 'minor', 'patch', 'pre', 'release', or 'first'
+
+        Options:
+      BANNER
 
       # Define the options for OptionParser
       # @return [void]
       # @api private
       def define_options
         # @sg-ignore
-        option_parser.banner = "Usage:\n#{command_template}"
-        option_parser.separator ''
-        option_parser.separator "RELEASE_TYPE must be 'major', 'minor', 'patch', 'pre', 'release', or 'first'"
-        option_parser.separator ''
-        option_parser.separator 'Options:'
+        option_parser.banner = BANNER
         %i[
           define_help_option define_default_branch_option define_release_branch_option define_pre_option
-          define_pre_type_option define_remote_option define_last_release_version_option
+          define_pre_type_option define_remote_option define_last_release_version_option define_version_option
           define_next_release_version_option define_changelog_path_option define_quiet_option define_verbose_option
         ].each { |m| send(m) }
       end
@@ -176,7 +175,7 @@ module CreateGithubRelease
       # @return [void]
       # @api private
       def define_verbose_option
-        option_parser.on('-v', '--[no-]verbose', 'Show extra output') do |verbose|
+        option_parser.on('-V', '--[no-]verbose', 'Show extra output') do |verbose|
           options.verbose = verbose
         end
       end
@@ -245,6 +244,16 @@ module CreateGithubRelease
       def define_changelog_path_option
         option_parser.on('--changelog-path=PATH', 'Use this file instead of CHANGELOG.md') do |name|
           options.changelog_path = name
+        end
+      end
+
+      # Define the version option
+      # @return [void]
+      # @api private
+      def define_version_option
+        option_parser.on_tail('-v', '--version', 'Output the version of this script') do
+          puts CreateGithubRelease::VERSION
+          exit 0
         end
       end
     end

--- a/spec/create_github_release/command_line/parser_spec.rb
+++ b/spec/create_github_release/command_line/parser_spec.rb
@@ -145,6 +145,14 @@ RSpec.describe CreateGithubRelease::CommandLine::Parser do
         it { is_expected.to have_attributes(release_type: 'patch', quiet: true) }
       end
 
+      context 'when the --version option is given' do
+        let(:args) { ['--version'] }
+        it 'should display the version and then exit' do
+          stub_const('CreateGithubRelease::VERSION', '9.9.9')
+          expect { subject }.to raise_error(SystemExit).and output(/^9.9.9\n$/).to_stdout
+        end
+      end
+
       context 'when the --help options is given' do
         let(:args) { ['--help'] }
         it 'should exit and display the command usage' do


### PR DESCRIPTION
Add the following options:

* `create-github-release --version | -v`
* `revert-github-release --version | -v`

This option should output the gem version and exit with status of 0.

Also, add the version to the `--help` output.