### PR TITLE
Require create_github_release/version where the gem version is needed

### DIFF
--- a/exe/revert-github-release
+++ b/exe/revert-github-release
@@ -5,6 +5,7 @@
 # It will delete the release branch and tag locally and remotely
 
 require 'create_github_release'
+require 'create_github_release/version'
 
 require 'English'
 require 'optparse'

--- a/lib/create_github_release/command_line/parser.rb
+++ b/lib/create_github_release/command_line/parser.rb
@@ -3,6 +3,7 @@
 require 'English'
 require 'optparse'
 require 'create_github_release/command_line/options'
+require 'create_github_release/version'
 
 module CreateGithubRelease
   module CommandLine


### PR DESCRIPTION
Both `create-github-release` and `revert-github-release` fail when trying to display the gem version which happens with both the --help and --version flags.

During development and testing, it was not necessary to:

```ruby
require 'create_github_release/version'
```

because this was required in the gemspec which gets evaluated when the scripts are run by bundle exec.

However, after being installed as a gem, this file is not required when the script is run from the command line.

This PR adds the require where needed.