### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.3.1 (2024-01-08)
+
+[Full Changelog](https://github.com/main-branch/create_github_release/compare/v1.3.0..v1.3.1)
+
+Changes since v1.3.0:
+
+* 7015e17 Require create_github_release/version where the gem version is needed (#50)
+
 ## v1.3.0 (2024-01-08)
 
 [Full Changelog](https://github.com/main-branch/create_github_release/compare/v1.2.0..v1.3.0)

--- a/lib/create_github_release/version.rb
+++ b/lib/create_github_release/version.rb
@@ -2,5 +2,5 @@
 
 module CreateGithubRelease
   # The version of this gem
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
# Release PR

## v1.3.1 (2024-01-08)

[Full Changelog](https://github.com/main-branch/create_github_release/compare/v1.3.0..v1.3.1)

Changes since v1.3.0:

* 7015e17 Require create_github_release/version where the gem version is needed (#50)
