### PR TITLE
Show release PR URL and other minor changes in the output

### DIFF
--- a/exe/create-github-release
+++ b/exe/create-github-release
@@ -13,18 +13,28 @@ puts unless options.quiet
 CreateGithubRelease::ReleaseTasks.new(project).run
 
 puts <<~MESSAGE unless project.quiet
-  Release '#{project.next_release_tag}' created successfully
-  See the release notes at #{project.release_url}
+  SUCCESS: created release '#{project.next_release_tag}'
 
   Next steps:
-  * Get someone to review and approve the release pull request
-  * Merge the pull request manually from the command line with the following commands:
+
+  * Review the release notes:
+
+  #{project.release_url}
+
+  * Get someone to review and approve the release pull request:
+
+  #{project.release_pr_url}
+
+  * Merge the pull request manually from the command line with the following
+    commands:
 
   git checkout #{project.default_branch}
   git merge --ff-only #{project.release_branch}
   git push
 
-  Wait for the CI build to pass and then release the gem with the following command:
+  * Wait for the CI build to pass on the default branch and then release the
+    gem with the following command:
 
   rake release:rubygem_push
+
 MESSAGE

--- a/exe/revert-github-release
+++ b/exe/revert-github-release
@@ -86,11 +86,13 @@ class Parser
     It must be run in the root directory of the work tree with the release
     branch checked out (which is the state create-github-release leaves you in).
 
-    This script should be run beefore the release PR is merged.
+    This script should be run before the release PR is merged.
 
-    This script removes the release branch and release tag both in the local
-    repository and on the remote. Deleting the branch on GitHub will close the
-    GitHub PR automatically.
+    This script does the following:
+      * Deletes the local and remote release branch
+      * Deletes the local and remote release tag
+      * Deletes the GitHub release object
+      * Closes the GitHub release PR
 
     Options:
   BANNER
@@ -172,4 +174,4 @@ end
 
 revert_release!(options)
 
-puts "Reverted release #{options.release_version}"
+puts "SUCCESS: reverted release '#{options.release_version}'"


### PR DESCRIPTION
This PR adds two attributes to the Project class:
* `#release_pr_number`: the PR number for the release
* `#release_pr_url`: the URL to the PR for the release

`create-github-release` was updated to show the release_pr_url to make it easy for the user to pull up the PR.