### PR TITLE
Format the output so next steps are easier to read

### DIFF
--- a/exe/create-github-release
+++ b/exe/create-github-release
@@ -35,28 +35,29 @@ puts unless options.quiet
 CreateGithubRelease::ReleaseTasks.new(project).run
 
 puts <<~MESSAGE unless project.quiet
+
   SUCCESS: created release '#{project.next_release_tag}'
 
   Next steps:
 
   * Review the release notes:
 
-  #{project.release_url}
+      #{project.release_url}
 
   * Get someone to review and approve the release pull request:
 
-  #{wait_for_non_nil(-> { project.release_pr_url }, max_attempts: 10, sleep_time: 0.5)}
+      #{wait_for_non_nil(-> { project.release_pr_url }, max_attempts: 10, sleep_time: 0.5)}
 
   * Merge the pull request manually from the command line with the following
     commands:
 
-  git checkout #{project.default_branch}
-  git merge --ff-only #{project.release_branch}
-  git push
+      git checkout #{project.default_branch}
+      git merge --ff-only #{project.release_branch}
+      git push
 
   * Wait for the CI build to pass on the default branch and then release the
     gem with the following command:
 
-  rake release:rubygem_push
+      rake release:rubygem_push
 
 MESSAGE


### PR DESCRIPTION
Format the output of `create-github-release so the next steps are easier to read, making the following changes:

* Add a blank link before the SUCCESS message
* Indent the instructions under each list item so the steps stand out more