### PR TITLE
Increment version with version_boss instead of semverify

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Options:
     -t, --pre-type=TYPE              Type of pre-release to create (e.g. alpha, beta, etc.)
         --remote=REMOTE_NAME         Use this remote name instead of 'origin'
         --last-release-version=VERSION
-                                     Use this version instead `semverify current`
+                                     Use this version instead `gem-version-boss current`
         --next-release-version=VERSION
-                                     Use this version instead `semverify next-RELEASE_TYPE`
+                                     Use this version instead `gem-version-boss next-RELEASE_TYPE`
         --changelog-path=PATH        Use this file instead of CHANGELOG.md
     -q, --[no-]quiet                 Do not show output
     -v, --[no-]verbose               Show extra output
@@ -90,10 +90,10 @@ If this is to be the first release of this gem follow these instructions.
 For this use case, let's assume the following:
 
 * the default branch is `main` (this is the HEAD branch returned by `git remote show origin`)
-* the current version of the gem is `0.1.0` (as returned by `semverify current`)
+* the current version of the gem is `0.1.0` (as returned by `gem-version-boss current`)
 
 If a different first version number is desired, update the version number in the
-source code making sure that `semverify current` returns the desired version number.
+source code making sure that `gem-version-boss current` returns the desired version number.
 Then commit the change to the default branch on the remote before running this
 script.
 
@@ -131,7 +131,7 @@ create-github-release first
 
 The `create-github-release` script will do the following:
 
-* Determine the next-release version (`v0.1.0`) using `semverify current`
+* Determine the next-release version (`v0.1.0`) using `gem-version-boss current`
 * Update the project's changelog file `CHANGELOG.md`
 * Create a release branch `release-v0.1.0`
 * Commit the changes to the changelog and create a release tag (`v0.1.0`) pointing
@@ -148,7 +148,7 @@ In order to start using `create-github-release` after you have used some other
 method for managing the gem version and creating releases, you need to ensure the
 following prerequisites are met:
 
-1. that `semverify current` is the version of the last release (let's use `1.3.1` as an
+1. that `gem-version-boss current` is the version of the last release (let's use `1.3.1` as an
    example).
 2. that there is a corresponding release tag that points to the last commit on the
    default branch of the previous release. If the last version was `1.3.1`, then
@@ -173,7 +173,7 @@ For this use case, let's assume the following:
 
 * you want to create a `major` release
 * the default branch is `main` (this is the HEAD branch returned by `git remote show origin`)
-* the current version of the gem is `0.1.0` (as returned by `semverify current`)
+* the current version of the gem is `0.1.0` (as returned by `gem-version-boss current`)
 
 The following prerequisites must be met:
 
@@ -196,9 +196,9 @@ create-github-release major
 
 The `create-github-release` script will do the following:
 
-* Determine the last-release version using `semverify current`
-* Determine the next-release version using `semverify RELEASE_TYPE --dry-run`
-* Increment the project's version using `semverify RELEASE_TYPE`
+* Determine the last-release version using `gem-version-boss current`
+* Determine the next-release version using `gem-version-boss RELEASE_TYPE --dry-run`
+* Increment the project's version using `gem-version-boss RELEASE_TYPE`
 * Update the project's changelog file `CHANGELOG.md`
 * Create a release branch `release-v1.0.0`
 * Commit the changes to the version and changelog AND create a release tag (`v1.0.0`) pointing

--- a/create_github_release.gemspec
+++ b/create_github_release.gemspec
@@ -35,17 +35,16 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'semverify', '~> 0.3'
+  spec.add_runtime_dependency 'version_boss', '~> 0.1'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
-  spec.add_development_dependency 'debug', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'redcarpet', '~> 3.5'
-  spec.add_development_dependency 'rspec', '~> 3.10'
-  spec.add_development_dependency 'rubocop', '~> 1.36'
-  spec.add_development_dependency 'simplecov', '~> 0.21'
+  spec.add_development_dependency 'debug', '~> 1.9'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'redcarpet', '~> 3.6'
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'rubocop', '~> 1.63'
+  spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
-  # spec.add_development_dependency 'solargraph', '~> 0.49'
   spec.add_development_dependency 'timecop', '~> 0.9'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yardstick', '~> 0.9'

--- a/exe/revert-github-release
+++ b/exe/revert-github-release
@@ -15,7 +15,7 @@ class Options
   attr_writer :default_branch, :release_version, :release_tag, :release_branch, :current_branch, :remote
 
   def default_branch = @default_branch ||= 'main'
-  def release_version = @release_version ||= `semverify current`.chomp
+  def release_version = @release_version ||= `gem-version-boss current`.chomp
   def release_tag = @release_tag ||= "v#{release_version}"
   def release_branch = @release_branch ||= "release-#{release_tag}"
   def current_branch = @current_branch ||= `git rev-parse --abbrev-ref HEAD`.chomp

--- a/lib/create_github_release/command_line/parser.rb
+++ b/lib/create_github_release/command_line/parser.rb
@@ -222,7 +222,8 @@ module CreateGithubRelease
       # @return [void]
       # @api private
       def define_last_release_version_option
-        option_parser.on('--last-release-version=VERSION', 'Use this version instead `semverify current`') do |version|
+        option_parser.on('--last-release-version=VERSION',
+                         'Use this version instead `gem-version-boss current`') do |version|
           options.last_release_version = version
         end
       end
@@ -233,7 +234,7 @@ module CreateGithubRelease
       def define_next_release_version_option
         option_parser.on(
           '--next-release-version=VERSION',
-          'Use this version instead `semverify next-RELEASE_TYPE`'
+          'Use this version instead `gem-version-boss next-RELEASE_TYPE`'
         ) do |version|
           options.next_release_version = version
         end

--- a/lib/create_github_release/project.rb
+++ b/lib/create_github_release/project.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'semverify'
+require 'version_boss'
 require 'uri'
 
 module CreateGithubRelease
@@ -194,7 +194,7 @@ module CreateGithubRelease
     #
     # The version of the next release
     #
-    # @example By default, `next_release_version` is based on the value returned by `semverify <release_type> --dry-run`
+    # @example By default, `next_release_version` is based on `gem-version-boss <release_type> --dry-run`
     #   options = CreateGithubRelease::CommandLine::Options.new(release_type: 'major')
     #   project = CreateGithubRelease::Project.new(options)
     #   project.next_release_version #=> '1.0.0'
@@ -207,7 +207,7 @@ module CreateGithubRelease
     #
     # @return [String]
     #
-    # @raise [RuntimeError] if the semverify command fails
+    # @raise [RuntimeError] if the gem-version-boss command fails
     #
     # @api public
     #
@@ -245,7 +245,7 @@ module CreateGithubRelease
     #
     # The version of the last release
     #
-    # @example By default, `last_release_version` is based on the value returned by `semverify current`
+    # @example By default, `last_release_version` is based on the value returned by `gem-version-boss current`
     #   options = CreateGithubRelease::CommandLine::Options.new(release_type: 'major')
     #   project = CreateGithubRelease::Project.new(options)
     #   project.last_release_version #=> '0.0.1'
@@ -258,7 +258,7 @@ module CreateGithubRelease
     #
     # @return [String]
     #
-    # @raise [RuntimeError] if the semverify command fails
+    # @raise [RuntimeError] if the gem-version-boss command fails
     #
     # @api public
     #
@@ -284,7 +284,7 @@ module CreateGithubRelease
     #
     # @return [String]
     #
-    # @raise [RuntimeError] if the semverify command fails
+    # @raise [RuntimeError] if the gem-version-boss command fails
     #
     # @api public
     #
@@ -312,7 +312,7 @@ module CreateGithubRelease
     #
     # @return [URI]
     #
-    # @raise [RuntimeError] if the semverify command fails
+    # @raise [RuntimeError] if the gem-version-boss command fails
     #
     # @api public
     #
@@ -369,7 +369,7 @@ module CreateGithubRelease
     #
     # The type of the release being created (e.g. 'major', 'minor', 'patch')
     #
-    # @note this must be one of the values accepted by the `semverify` command
+    # @note this must be one of the values accepted by the `gem-version-boss` command
     #
     # @example By default, this value comes from the options object
     #   options = CreateGithubRelease::CommandLine::Options.new(release_type: 'major')
@@ -913,22 +913,22 @@ module CreateGithubRelease
 
     private
 
-    # The current version of the project as determined by semverify
+    # The current version of the project as determined by gem-version-boss
     # @return [String] The current version of the project
     # @api private
     def current_version
-      output = `semverify current`
-      raise 'Could not determine current version using semverify' unless $CHILD_STATUS.success?
+      output = `gem-version-boss current`
+      raise 'Could not determine current version using gem-version-boss' unless $CHILD_STATUS.success?
 
       output.lines.last.chomp
     end
 
-    # The next version of the project as determined by semverify and release_type
+    # The next version as determined by gem-version-boss and release_type
     # @return [String] The next version of the project
     # @api private
     def next_version
       output = `#{next_version_cmd}`
-      raise 'Could not determine next version using semverify' unless $CHILD_STATUS.success?
+      raise 'Could not determine next version using gem-version-boss' unless $CHILD_STATUS.success?
 
       output.lines.last.chomp
     end
@@ -937,7 +937,7 @@ module CreateGithubRelease
     # @return [String]
     # @api private
     def next_version_cmd
-      cmd = "semverify next-#{release_type}"
+      cmd = "gem-version-boss next-#{release_type}"
       cmd << ' --pre' if pre
       cmd << " --pre-type=#{pre_type}" if pre_type
       cmd << ' --dry-run'

--- a/lib/create_github_release/tasks/update_version.rb
+++ b/lib/create_github_release/tasks/update_version.rb
@@ -5,12 +5,12 @@ require 'create_github_release/task_base'
 
 module CreateGithubRelease
   module Tasks
-    # Update the gem version using semverify
+    # Update the gem version using gem-version-boss
     #
     # @api public
     #
     class UpdateVersion < TaskBase
-      # Update the gem version using semverify
+      # Update the gem version using gem-version-boss
       #
       # @example
       #   require 'create_github_release'
@@ -39,28 +39,28 @@ module CreateGithubRelease
 
       private
 
-      # Increment the version using semverify
+      # Increment the version using gem-version-boss
       # @return [void]
       # @api private
       def increment_version
-        command = "semverify next-#{project.release_type}"
+        command = "gem-version-boss next-#{project.release_type}"
         command += ' --pre' if project.pre
         command += " --pre-type=#{project.pre_type}" if project.pre_type
         `#{command}`
         error 'Could not increment version' unless $CHILD_STATUS.success?
       end
 
-      # Return the path the the version file using semverify
+      # Return the path the the version file using gem-version-boss
       # @return [String]
       # @api private
       def version_file
-        output = `semverify file`
-        error 'Semverify could determine the version file' unless $CHILD_STATUS.success?
+        output = `gem-version-boss file`
+        error 'Could determine the version file' unless $CHILD_STATUS.success?
 
         output.lines.last.chomp
       end
 
-      # Identify the version file using semverify and stage the change to it
+      # Identify the version file using gem-version-boss and stage the change to it
       # @return [void]
       # @api private
       def stage_version_file

--- a/spec/create_github_release/project_spec.rb
+++ b/spec/create_github_release/project_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe CreateGithubRelease::Project do
       end
     end
 
-    context "when release_type is 'first' and 'semverify current' returns 0.0.1" do
+    context "when release_type is 'first' and 'gem-version-boss current' returns 0.0.1" do
       let(:release_type) { 'first' }
 
       subject { project }
 
-      let(:mocked_commands) { [MockedCommand.new('semverify current', stdout: "0.0.1\n")] }
+      let(:mocked_commands) { [MockedCommand.new('gem-version-boss current', stdout: "0.0.1\n")] }
 
       it do
         is_expected.to(
@@ -200,8 +200,8 @@ RSpec.describe CreateGithubRelease::Project do
     context 'when not explicitly set and not set in options' do
       context 'when this is the first release' do
         let(:release_type) { 'first' }
-        let(:mocked_commands) { [MockedCommand.new('semverify current', stdout: "1.0.0\n")] }
-        it "should determine the version using 'semverify current'" do
+        let(:mocked_commands) { [MockedCommand.new('gem-version-boss current', stdout: "1.0.0\n")] }
+        it "should determine the version using 'gem-version-boss current'" do
           expect(subject).to eq('1.0.0')
         end
       end
@@ -217,7 +217,7 @@ RSpec.describe CreateGithubRelease::Project do
 
           let(:mocked_commands) do
             [
-              MockedCommand.new('semverify next-pre --pre --dry-run', stdout: "1.0.0-alpha.2\n")
+              MockedCommand.new('gem-version-boss next-pre --pre --dry-run', stdout: "1.0.0-alpha.2\n")
             ]
           end
 
@@ -235,7 +235,7 @@ RSpec.describe CreateGithubRelease::Project do
 
           let(:mocked_commands) do
             [
-              MockedCommand.new('semverify next-pre --pre --pre-type=beta --dry-run', stdout: "1.0.0-beta.1\n")
+              MockedCommand.new('gem-version-boss next-pre --pre --pre-type=beta --dry-run', stdout: "1.0.0-beta.1\n")
             ]
           end
 
@@ -248,7 +248,7 @@ RSpec.describe CreateGithubRelease::Project do
 
         let(:mocked_commands) do
           [
-            MockedCommand.new('semverify next-release --dry-run', stdout: "1.0.0\n")
+            MockedCommand.new('gem-version-boss next-release --dry-run', stdout: "1.0.0\n")
           ]
         end
 
@@ -256,22 +256,22 @@ RSpec.describe CreateGithubRelease::Project do
       end
 
       context 'when release_type is major' do
-        context 'when the semverify command succeeds' do
-          let(:mocked_commands) { [MockedCommand.new('semverify next-major --dry-run', stdout: "1.0.0\n")] }
+        context 'when the gem-version-boss command succeeds' do
+          let(:mocked_commands) { [MockedCommand.new('gem-version-boss next-major --dry-run', stdout: "1.0.0\n")] }
           it { is_expected.to eq('1.0.0') }
         end
 
-        context 'when the semverify command succeeds with extra output' do
+        context 'when the gem-version-boss command succeeds with extra output' do
           let(:mocked_commands) do
             [
-              MockedCommand.new('semverify next-major --dry-run', stdout: "Resolving dependencies...\n1.0.0\n")
+              MockedCommand.new('gem-version-boss next-major --dry-run', stdout: "Resolving dependencies...\n1.0.0\n")
             ]
           end
           it { is_expected.to eq('1.0.0') }
         end
 
-        context 'when the semverify command fails' do
-          let(:mocked_commands) { [MockedCommand.new('semverify next-major --dry-run', exitstatus: 1)] }
+        context 'when the gem-version-boss command fails' do
+          let(:mocked_commands) { [MockedCommand.new('gem-version-boss next-major --dry-run', exitstatus: 1)] }
           it 'should raise a RuntimeError' do
             expect { subject }.to raise_error(RuntimeError)
           end
@@ -287,7 +287,8 @@ RSpec.describe CreateGithubRelease::Project do
 
           let(:mocked_commands) do
             [
-              MockedCommand.new('semverify next-major --pre --pre-type=alpha --dry-run', stdout: "1.0.0-alpha.1\n")
+              MockedCommand.new('gem-version-boss next-major --pre --pre-type=alpha --dry-run',
+                                stdout: "1.0.0-alpha.1\n")
             ]
           end
 
@@ -348,28 +349,28 @@ RSpec.describe CreateGithubRelease::Project do
 
       context 'when this is the first release' do
         let(:release_type) { 'first' }
-        let(:mocked_commands) { [MockedCommand.new('semverify current', stdout: '0.0.1')] }
+        let(:mocked_commands) { [MockedCommand.new('gem-version-boss current', stdout: '0.0.1')] }
         it 'should return an empty string' do
           expect(subject).to eq('')
         end
       end
 
-      context 'when the semverify command succeeds' do
-        let(:mocked_commands) { [MockedCommand.new('semverify current', stdout: "0.0.1\n")] }
+      context 'when the gem-version-boss command succeeds' do
+        let(:mocked_commands) { [MockedCommand.new('gem-version-boss current', stdout: "0.0.1\n")] }
         it { is_expected.to eq('0.0.1') }
       end
 
-      context 'when the semverify command succeeds with extra output' do
+      context 'when the gem-version-boss command succeeds with extra output' do
         let(:mocked_commands) do
           [
-            MockedCommand.new('semverify current', stdout: "Resolving dependencies...\n0.0.1\n")
+            MockedCommand.new('gem-version-boss current', stdout: "Resolving dependencies...\n0.0.1\n")
           ]
         end
         it { is_expected.to eq('0.0.1') }
       end
 
-      context 'when the semverify command fails' do
-        let(:mocked_commands) { [MockedCommand.new('semverify current', exitstatus: '1')] }
+      context 'when the gem-version-boss command fails' do
+        let(:mocked_commands) { [MockedCommand.new('gem-version-boss current', exitstatus: '1')] }
         it 'should raise a RuntimeError' do
           expect { subject }.to raise_error(RuntimeError)
         end
@@ -1091,9 +1092,9 @@ RSpec.describe CreateGithubRelease::Project do
     let(:mocked_commands) do
       [
         MockedCommand.new("git remote show 'origin'", stdout: "  HEAD branch: main\n"),
-        MockedCommand.new('semverify next-major --dry-run', stdout: "1.0.0\n"),
+        MockedCommand.new('gem-version-boss next-major --dry-run', stdout: "1.0.0\n"),
         MockedCommand.new('git show --format=format:%aI --quiet "v1.0.0"', stdout: "2023-02-01 00:00:00 -0800\n"),
-        MockedCommand.new('semverify current', stdout: "0.1.0\n"),
+        MockedCommand.new('gem-version-boss current', stdout: "0.1.0\n"),
         MockedCommand.new("git remote get-url 'origin'", stdout: "https://github.com/org/repo.git\n"),
         MockedCommand.new('git tag --list "v1.0.0"', stdout: "v1.0.0\n"),
         MockedCommand.new('gh pr list --search "head:release-v1.0.0" --json number --jq ".[].number"', stdout: "123\n")

--- a/spec/create_github_release/tasks/update_version_spec.rb
+++ b/spec/create_github_release/tasks/update_version_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
 
       let(:mocked_commands) do
         [
-          MockedCommand.new('semverify next-major --pre', exitstatus: semverify_exitstatus),
-          MockedCommand.new('semverify file', stdout: "#{version_file}\n", exitstatus: semverify_file_exitstatus),
+          MockedCommand.new('gem-version-boss next-major --pre', exitstatus: next_exitstatus),
+          MockedCommand.new('gem-version-boss file', stdout: "#{version_file}\n", exitstatus: file_exitstatus),
           MockedCommand.new("git add \"#{version_file}\"", exitstatus: git_exitstatus)
         ]
       end
 
-      let(:semverify_exitstatus) { 0 }
-      let(:semverify_file_exitstatus) { 0 }
+      let(:next_exitstatus) { 0 }
+      let(:file_exitstatus) { 0 }
       let(:git_exitstatus) { 0 }
 
       it 'should increment the version with the --pre flag' do
@@ -63,14 +63,14 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
 
       let(:mocked_commands) do
         [
-          MockedCommand.new('semverify next-major --pre --pre-type=alpha', exitstatus: semverify_exitstatus),
-          MockedCommand.new('semverify file', stdout: "#{version_file}\n", exitstatus: semverify_file_exitstatus),
+          MockedCommand.new('gem-version-boss next-major --pre --pre-type=alpha', exitstatus: next_exitstatus),
+          MockedCommand.new('gem-version-boss file', stdout: "#{version_file}\n", exitstatus: file_exitstatus),
           MockedCommand.new("git add \"#{version_file}\"", exitstatus: git_exitstatus)
         ]
       end
 
-      let(:semverify_exitstatus) { 0 }
-      let(:semverify_file_exitstatus) { 0 }
+      let(:next_exitstatus) { 0 }
+      let(:file_exitstatus) { 0 }
       let(:git_exitstatus) { 0 }
 
       it 'should increment the version with the --pre and --pre-type=alpha args' do
@@ -84,14 +84,14 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
 
       let(:mocked_commands) do
         [
-          MockedCommand.new('semverify next-pre --pre-type=beta', exitstatus: semverify_exitstatus),
-          MockedCommand.new('semverify file', stdout: "#{version_file}\n", exitstatus: semverify_file_exitstatus),
+          MockedCommand.new('gem-version-boss next-pre --pre-type=beta', exitstatus: next_exitstatus),
+          MockedCommand.new('gem-version-boss file', stdout: "#{version_file}\n", exitstatus: file_exitstatus),
           MockedCommand.new("git add \"#{version_file}\"", exitstatus: git_exitstatus)
         ]
       end
 
-      let(:semverify_exitstatus) { 0 }
-      let(:semverify_file_exitstatus) { 0 }
+      let(:next_exitstatus) { 0 }
+      let(:file_exitstatus) { 0 }
       let(:git_exitstatus) { 0 }
 
       it 'should increment the version with the pre release type and --pre-type=alpha arg' do
@@ -102,35 +102,35 @@ RSpec.describe CreateGithubRelease::Tasks::UpdateVersion do
     context 'when this is NOT the first release' do
       let(:mocked_commands) do
         [
-          MockedCommand.new('semverify next-major', exitstatus: semverify_exitstatus),
-          MockedCommand.new('semverify file', stdout: "#{version_file}\n", exitstatus: semverify_file_exitstatus),
+          MockedCommand.new('gem-version-boss next-major', exitstatus: next_exitstatus),
+          MockedCommand.new('gem-version-boss file', stdout: "#{version_file}\n", exitstatus: file_exitstatus),
           MockedCommand.new("git add \"#{version_file}\"", exitstatus: git_exitstatus)
         ]
       end
 
-      let(:semverify_exitstatus) { 0 }
-      let(:semverify_file_exitstatus) { 0 }
+      let(:next_exitstatus) { 0 }
+      let(:file_exitstatus) { 0 }
       let(:git_exitstatus) { 0 }
 
-      context 'when semverify and git add succeed' do
+      context 'when gem-version-boss and git add succeed' do
         it 'should succeed' do
           expect { subject }.not_to raise_error
         end
       end
 
-      context 'when semverify fails to increment the version' do
-        let(:semverify_exitstatus) { 1 }
+      context 'when gem-version-boss fails to increment the version' do
+        let(:next_exitstatus) { 1 }
         it 'should fail' do
           expect { subject }.to raise_error(SystemExit)
           expect(stderr).to start_with('ERROR: Could not increment version')
         end
       end
 
-      context 'when `semverify file` fails' do
-        let(:semverify_file_exitstatus) { 1 }
+      context 'when `gem-version-boss file` fails' do
+        let(:file_exitstatus) { 1 }
         it 'should fail' do
           expect { subject }.to raise_error(SystemExit)
-          expect(stderr).to start_with('ERROR: Semverify could determine the version file')
+          expect(stderr).to start_with('ERROR: Could determine the version file')
         end
       end
 


### PR DESCRIPTION
Because Semverify does not propery handle gem pre-release version numbers, switch to version_boss.

version_boss handles Ruby gem prerelease versions correctly and has the same interface.