### PR TITLE
Fix rubocop offense and test errors

### DIFF
--- a/create_github_release.gemspec
+++ b/create_github_release.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'version_boss', '~> 0.1'
+  spec.add_dependency 'version_boss', '~> 0.1'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'debug', '~> 1.9'

--- a/spec/create_github_release/command_line/options_spec.rb
+++ b/spec/create_github_release/command_line/options_spec.rb
@@ -277,7 +277,10 @@ RSpec.describe CreateGithubRelease::CommandLine::Options do
           before { options.pre = true }
 
           it 'is expected NOT to be valid' do
-            expect(subject).to have_attributes(valid?: false, errors: [/^--pre can only /, /^--pre-type can only /])
+            expect(subject).to have_attributes(
+              valid?: false,
+              errors: match_array([/^--pre can only /, /^--pre-type can only /])
+            )
           end
         end
 
@@ -297,7 +300,10 @@ RSpec.describe CreateGithubRelease::CommandLine::Options do
           before { options.pre = true }
 
           it 'is expected NOT to be valid' do
-            expect(subject).to have_attributes(valid?: false, errors: [/^--pre can only /, /^--pre-type can only /])
+            expect(subject).to have_attributes(
+              valid?: false,
+              errors: match_array([/^--pre can only /, /^--pre-type can only /])
+            )
           end
         end
 
@@ -305,7 +311,9 @@ RSpec.describe CreateGithubRelease::CommandLine::Options do
           before { options.pre = false }
 
           it 'is expected NOT to be valid' do
-            expect(subject).to have_attributes(valid?: false, errors: [/^--pre-type can only /])
+            expect(subject).to have_attributes(
+              valid?: false, errors: [/^--pre-type can only /]
+            )
           end
         end
       end


### PR DESCRIPTION
This pull request includes two commits. 

1. The first commit fixes a rubocop offense related to the new Gemspec/AddRuntimeDependency cop.

2. The second commit fixes test errors caused by an array not being in the expected order.