### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.5.0 (2024-09-10)
+
+[Full Changelog](https://github.com/main-branch/create_github_release/compare/v1.4.0..v1.5.0)
+
+Changes since v1.4.0:
+
+* fdc35ee Optionally apply a release label to release PRs
+* c122e7f Add Semver PR Label Check workflow
+* afc3883 Update to the latest version of the CodeClimate test coverage reporter
+* 0a57cbd Fix test errors due to array being in different order
+* 30d46fb Fix rubocop offense from new Gemspec/AddRuntimeDependency cop
+
 ## v1.4.0 (2024-05-10)
 
 [Full Changelog](https://jcouball@github.com/main-branch/create_github_release/compare/v1.3.4..v1.4.0)

--- a/lib/create_github_release/version.rb
+++ b/lib/create_github_release/version.rb
@@ -2,5 +2,5 @@
 
 module CreateGithubRelease
   # The version of this gem
-  VERSION = '1.4.0'
+  VERSION = '1.5.0'
 end


### PR DESCRIPTION
# Release PR

## v1.5.0 (2024-09-10)

[Full Changelog](https://github.com/main-branch/create_github_release/compare/v1.4.0..v1.5.0)

Changes since v1.4.0:

* fdc35ee Optionally apply a release label to release PRs
* c122e7f Add Semver PR Label Check workflow
* afc3883 Update to the latest version of the CodeClimate test coverage reporter
* 0a57cbd Fix test errors due to array being in different order
* 30d46fb Fix rubocop offense from new Gemspec/AddRuntimeDependency cop
