### PR TITLE
Depend on v1 of semver_pr_label_check

### DIFF
--- a/.github/workflows/semver_pr_label_check.yml
+++ b/.github/workflows/semver_pr_label_check.yml
@@ -1,8 +1,5 @@
 name: Semver PR Label Check
 
-# Enforces that every PR must have a semver label: major-change, minor-change,
-# patch-change, internal-change, or release
-
 on:
   pull_request:
     branches: [main]
@@ -10,6 +7,6 @@ on:
 
 jobs:
   run_semver_pr_label_check:
-    uses: main-branch/semver_pr_label_check/.github/workflows/semver_pr_label_check.yml@main
+    uses: main-branch/semver_pr_label_check/.github/workflows/semver_pr_label_check.yml@v1
     secrets:
       repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the dependency on semver_pr_label_check to v1 (a tag) instead of main (a branch). This should avoid getting breaking changes.
