### PR TITLE
Set JRuby —debug option when running tests in GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -9,6 +9,11 @@ on:
 
   workflow_dispatch:
 
+env:
+  # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
+  # results from JRuby are complete.
+  JRUBY_OPTS: --debug
+
 # Supported platforms / Ruby versions:
 #  - Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
 #  - Windows: MRI (3.1), JRuby (9.4)

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -6,6 +6,11 @@ on:
 
   workflow_dispatch:
 
+env:
+  # SimpleCov suggests setting the JRuby --debug flag to ensure that coverage
+  # results from JRuby are complete.
+  JRUBY_OPTS: --debug
+
 # Experimental platforms / Ruby versions:
 #  - Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
 #  - Windows: MRI (head), JRuby (head)
@@ -13,7 +18,7 @@ on:
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
-    
+
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 


### PR DESCRIPTION
SimpleCov suggests using the `--debug` option in to ensure that code coverage is reported correctly.

When SimpleCov is run in JRuby, it gives the warning:

```
Coverage may be inaccurate; set the "--debug" command line option, or do 
JRUBY_OPTS="--debug" or set the "debug.fullTrace=true" option in your .jrubyrc
```

This PR adds the JRUBY_OPTS environment variable in all GitHub Actions workflows at the global level.