### PR TITLE
Use shared Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,23 +1,7 @@
+inherit_gem:
+  main_branch_shared_rubocop_config: config/rubocop.yml
+
 AllCops:
-  NewCops: enable
-  # Output extra information for each offense to make it easier to diagnose:
-  DisplayCopNames: true
-  DisplayStyleGuide: true
-  ExtraDetails: true
-  SuggestExtensions: false
-  # RuboCop enforces rules depending on the oldest version of Ruby which
-  # your project supports:
+  # Pin this project to Ruby 3.1 in case the shared config above is upgraded to 3.2
+  # or later.
   TargetRubyVersion: 3.1
-
-# The default max line length is 80 characters
-Layout/LineLength:
-  Max: 120
-
-# The DSL for RSpec and the gemspec file make it very hard to limit block length:
-Metrics/BlockLength:
-  Exclude:
-    - "spec/**/*_spec.rb"
-    - "*.gemspec"
-
-Gemspec/DevelopmentDependencies:
-  EnforcedStyle: gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -49,14 +49,9 @@ CLEAN << 'rspec-report.xml'
 
 require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new do |t|
-  t.options = %w[
-    --format progress
-    --format json --out rubocop-report.json
-  ]
-end
+RuboCop::RakeTask.new
 
-CLEAN << 'rubocop-report.json'
+# YARD
 
 unless RUBY_PLATFORM == 'java'
   # yard:build

--- a/create_github_release.gemspec
+++ b/create_github_release.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   # spec.add_development_dependency 'debug', '~> 1.9'
+  spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.66'


### PR DESCRIPTION
Update the .rubocop.yml to inherit from a shared Rubocop config from the main_branch_shared_rubocop_config gem.