### PR TITLE
Use the command_line_boss gem for CLI parsing

### DIFF
--- a/create_github_release.gemspec
+++ b/create_github_release.gemspec
@@ -43,7 +43,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'version_boss', '~> 0.1'
 
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
+  spec.add_development_dependency 'command_line_boss', '~> 0.1'
   # spec.add_development_dependency 'debug', '~> 1.9'
+  spec.add_development_dependency 'logger', '~> 1.6'
   spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'

--- a/exe/create-github-release
+++ b/exe/create-github-release
@@ -25,7 +25,7 @@ def wait_for_non_nil(method, max_attempts: 10, sleep_time: 0.5)
   result
 end
 
-options = CreateGithubRelease::CommandLine::Parser.new.parse(*ARGV)
+options = CreateGithubRelease::CommandLine::Parser.new.parse!(ARGV).options
 pp options if options.verbose
 
 project = CreateGithubRelease::Project.new(options)

--- a/spec/create_github_release/command_line/parser_spec.rb
+++ b/spec/create_github_release/command_line/parser_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CreateGithubRelease::CommandLine::Parser do
   end
 
   describe '#parse' do
-    subject { parser.parse(*args) }
+    subject { parser.parse!(args).options }
 
     context 'when a release type is not given' do
       let(:args) { [] }
@@ -252,7 +252,7 @@ RSpec.describe CreateGithubRelease::CommandLine::Parser do
       context 'when too many args are given' do
         let(:args) { %w[major minor] }
         it 'should exit' do
-          expect { subject }.to raise_error(SystemExit).and output(/^ERROR: Too many args/).to_stderr
+          expect { subject }.to raise_error(SystemExit).and output(/^ERROR: Unexpected arguments: minor/).to_stderr
         end
       end
 


### PR DESCRIPTION
Instead of implementing parsing, use the [command_line_boss](https://github.com/main-branch/command_line_boss) gem to implement the parsing.

There were only a few class interface tweaks that needed to be made. Other than that, tests are largely unchanged.

This ended up shrinking the CreateGithubRelease::CommandLine::Parser class by 22% (from 274 lines to 213 lines).