### PR TITLE
fix: the release commit subject should not be sentence case

### DIFF
--- a/lib/create_github_release/tasks/commit_release.rb
+++ b/lib/create_github_release/tasks/commit_release.rb
@@ -31,7 +31,7 @@ module CreateGithubRelease
       #
       def run
         print 'Making release commit...'
-        `git commit -s -m 'chore: Release #{project.next_release_tag}'`
+        `git commit -s -m 'chore: release #{project.next_release_tag}'`
         if $CHILD_STATUS.success?
           puts 'OK'
         else

--- a/spec/create_github_release/tasks/commit_release_spec.rb
+++ b/spec/create_github_release/tasks/commit_release_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe CreateGithubRelease::Tasks::CommitRelease do
 
     let(:mocked_commands) do
       [
-        MockedCommand.new("git commit -s -m 'chore: Release #{next_release_tag}'", exitstatus: git_exitstatus)
+        MockedCommand.new("git commit -s -m 'chore: release #{next_release_tag}'", exitstatus: git_exitstatus)
       ]
     end
 


### PR DESCRIPTION
Instead of "chore: Release v1.2.3"
the commit message should be "chore: release v1.2.3"
with a lowercase "release".