### PR TITLE
Release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.1.1 (2024-10-10)
+
+[Full Changelog](https://github.com/main-branch/create_github_release/compare/v2.1.0..v2.1.1)
+
+Changes since v2.1.0:
+
+* d44db95 fix: the release commit subject should not be sentence case
+
 ## v2.1.0 (2024-10-10)
 
 [Full Changelog](https://github.com/main-branch/create_github_release/compare/v2.0.1..v2.1.0)

--- a/lib/create_github_release/version.rb
+++ b/lib/create_github_release/version.rb
@@ -2,5 +2,5 @@
 
 module CreateGithubRelease
   # The version of this gem
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
# Release PR

## v2.1.1 (2024-10-10)

[Full Changelog](https://github.com/main-branch/create_github_release/compare/v2.1.0..v2.1.1)

Changes since v2.1.0:

* d44db95 fix: the release commit subject should not be sentence case
