### PR TITLE
Release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.1.2 (2024-10-10)
+
+[Full Changelog](https://github.com/main-branch/create_github_release/compare/v2.1.1..v2.1.2)
+
+Changes since v2.1.1:
+
+* 0bb1a31 build: remove semver pr label check
+* 1c5f446 build: enforce conventional commit message formatting
+
 ## v2.1.1 (2024-10-10)
 
 [Full Changelog](https://github.com/main-branch/create_github_release/compare/v2.1.0..v2.1.1)

--- a/lib/create_github_release/version.rb
+++ b/lib/create_github_release/version.rb
@@ -2,5 +2,5 @@
 
 module CreateGithubRelease
   # The version of this gem
-  VERSION = '2.1.1'
+  VERSION = '2.1.2'
 end


### PR DESCRIPTION
# Release PR

## v2.1.2 (2024-10-10)

[Full Changelog](https://github.com/main-branch/create_github_release/compare/v2.1.1..v2.1.2)

Changes since v2.1.1:

* 0bb1a31 build: remove semver pr label check
* 1c5f446 build: enforce conventional commit message formatting
