### PR TITLE
Remove unused yardoc references and improve validation logic

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -3,6 +3,4 @@
 --markup-provider=redcarpet
 --markup markdown
 - CHANGELOG.md
-- CONTRIBUTING.md
-- RELEASING.md
 - LICENSE.txt

--- a/exe/revert-github-release
+++ b/exe/revert-github-release
@@ -76,7 +76,7 @@ class Parser
     COMMAND
   end
 
-  BANNER = <<~BANNER.freeze
+  private_constant BANNER = <<~BANNER.freeze
     Usage:
     #{File.basename($PROGRAM_NAME)} [--help | --version]
 

--- a/lib/create_github_release/command_line/validations.rb
+++ b/lib/create_github_release/command_line/validations.rb
@@ -119,7 +119,7 @@ module CreateGithubRelease
         # @return [Boolean]
         # @api private
         def valid?
-          options.quiet == true || options.quiet == false
+          [true, false].include? options.quiet
         end
 
         # Called when valid? is `false` to return the error messages
@@ -137,7 +137,7 @@ module CreateGithubRelease
         # @return [Boolean]
         # @api private
         def valid?
-          options.verbose == true || options.verbose == false
+          [true, false].include? options.verbose
         end
 
         # Called when valid? is `false` to return the error messages


### PR DESCRIPTION
Eliminate references to files not included in the project and enhance the validation checks for quiet and verbose options by simplifying the logic. Additionally, make the BANNER constant private to encapsulate its usage.