### PR TITLE
build(dependencies): update dependencies for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
       - name: Check Commit Messages

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}

--- a/exe/revert-github-release
+++ b/exe/revert-github-release
@@ -24,7 +24,7 @@ class Options
 end
 
 # Parse the command line options for this script
-class Parser
+class Parser # rubocop:disable Style/OneClassPerFile
   # Create a new command line parser
   #
   # @example

--- a/lib/create_github_release/changelog.rb
+++ b/lib/create_github_release/changelog.rb
@@ -108,7 +108,7 @@ module CreateGithubRelease
     def front_matter
       return '' if front_matter_start == front_matter_end
 
-      lines[front_matter_start..front_matter_end - 1].join("\n")
+      lines[front_matter_start..(front_matter_end - 1)].join("\n")
     end
 
     # The body of the existing changelog
@@ -168,7 +168,7 @@ module CreateGithubRelease
     def body
       return '' if body_start == body_end
 
-      lines[body_start..body_end - 1].join("\n")
+      lines[body_start..(body_end - 1)].join("\n")
     end
 
     # The changelog before the new release is added

--- a/lib/create_github_release/command_line/options.rb
+++ b/lib/create_github_release/command_line/options.rb
@@ -139,6 +139,7 @@ module CreateGithubRelease
       end
 
       extend Forwardable
+
       def_delegators :@validator, :valid?, :errors
 
       private

--- a/spec/create_github_release/backtick_debug_spec.rb
+++ b/spec/create_github_release/backtick_debug_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe CreateGithubRelease::BacktickDebug do
       let(:including_class) do
         Class.new do
           include CreateGithubRelease::BacktickDebug
+
           def backtick_debug?
             false
           end
@@ -27,6 +28,7 @@ RSpec.describe CreateGithubRelease::BacktickDebug do
         let(:including_class) do
           Class.new do
             include CreateGithubRelease::BacktickDebug
+
             def backtick_debug?
               true
             end
@@ -55,6 +57,7 @@ RSpec.describe CreateGithubRelease::BacktickDebug do
         let(:including_class) do
           Class.new do
             include CreateGithubRelease::BacktickDebug
+
             def backtick_debug?
               true
             end


### PR DESCRIPTION
## Summary

Update GitHub Actions workflow dependencies to the latest major versions.

### Updated Actions

- `actions/checkout`: `@v4` → `@v6` (latest: v6.0.2)
- `googleapis/release-please-action`: `@v4` → `@v5` (latest: v5.0.0)

### No Change Needed

- `ruby/setup-ruby@v1` — latest is still v1 (latest: v1.305.0)
- `wagoid/commitlint-github-action@v6` — latest is still v6 (latest: v6.2.1)
- `rubygems/release-gem@v1` — latest is still v1 (latest: v1.2.0)

### RuboCop Fixes

Also fixes RuboCop offenses introduced by new cops:
- `Lint/AmbiguousRange` in `changelog.rb`
- `Layout/EmptyLinesAfterModuleInclusion` in `options.rb` and `backtick_debug_spec.rb`
- `Style/OneClassPerFile` in `exe/revert-github-release`